### PR TITLE
85 disable pv write access when ioc is starting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ bin
 lib
 include
 db
+!pixciApp/Db
 dbd
 *_BAK.adl
 documentation.html

--- a/pixciApp/Db/Pixci.template
+++ b/pixciApp/Db/Pixci.template
@@ -58,6 +58,7 @@ record(bi, "$(P)$(R)TriggerPolarity_RBV")
    field(SCAN, "I/O Intr")
 }
 
+# TODO: add comments
 record(dfanout, "$(P)$(R)WriteEnabler") {
    field(DOL, "0")
    field(OUTA, "$(P)$(R)WriteEnabler.DISV")

--- a/pixciApp/Db/Pixci.template
+++ b/pixciApp/Db/Pixci.template
@@ -1,8 +1,13 @@
+# Pixci.template
+# Database template for ADPixci, overrides some records from ADBase (ADCore) 
+# and adds Pixci specific records
+#
+
 include "ADBase.template"
 
-######################
-# Override ADBase to extend Trigger Mode
-######################
+################################################################################
+# Override ADBase to extend Trigger Mode and RBV
+#
 record(mbbo, "$(P)$(R)TriggerMode")
 {
    field(ZRST, "Live - ITR")
@@ -29,6 +34,9 @@ record(mbbi, "$(P)$(R)TriggerMode_RBV")
    field(FLNK, "$(P)$(R)WriteEnabler")
 }
 
+################################################################################
+# Records for sending a soft trigger and setting external trigger mode polarity
+#
 record(bo, "$(P)$(R)SoftTrigger")
 {
    field(DTYP, "asynInt32")
@@ -58,7 +66,10 @@ record(bi, "$(P)$(R)TriggerPolarity_RBV")
    field(SCAN, "I/O Intr")
 }
 
-# TODO: add comments
+################################################################################
+# Record for enabling write access of various PVs after the device has first
+# initialised and sent a Trigger Mode back to the IOC
+#
 record(dfanout, "$(P)$(R)WriteEnabler") {
    field(DOL, "0")
    field(OUTA, "$(P)$(R)WriteEnabler.DISV")
@@ -69,23 +80,9 @@ record(dfanout, "$(P)$(R)WriteEnabler") {
    field(OMSL, "closed_loop")
 }
 
-record(bo, "$(P)$(R)UpdateTemperature")
-{
-   field(DTYP, "asynInt32")
-   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_UPDATE_TEMPERATURE")
-   field(ZNAM, "Updated")
-   field(ONAM, "Updated")
-   field(SCAN, "5 second")
-}
-
-record(bo, "$(P)$(R)UpdateStatus")
-{
-   field(DTYP, "asynInt32")
-   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_UPDATE_STATUS")
-   field(ZNAM, "Updated")
-   field(ONAM, "Updated")
-}
-
+################################################################################
+# Record for the temperature reading from the device PCB 
+#
 record(ai, "$(P)$(R)TemperaturePCB")
 {
    field(DTYP, "asynFloat64")
@@ -95,6 +92,20 @@ record(ai, "$(P)$(R)TemperaturePCB")
    field(SCAN, "I/O Intr")
 }
 
+################################################################################
+# TODO: check with Aoun about this record as the git blame shows that he wrote it
+#
+record(bo, "$(P)$(R)UpdateStatus")
+{
+   field(DTYP, "asynInt32")
+   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_UPDATE_STATUS")
+   field(ZNAM, "Updated")
+   field(ONAM, "Updated")
+}
+
+################################################################################
+# Records related to ThermoElectric Cooling (TEC)
+#
 record(bo, "$(P)$(R)ToggleTEC")
 {
    field(DTYP, "asynInt32")
@@ -112,6 +123,48 @@ record(bi, "$(P)$(R)ToggleTEC_RBV")
    field(SCAN, "I/O Intr")
 }
 
+record(bo, "$(P)$(R)UpdateTemperature")
+{
+   field(DTYP, "asynInt32")
+   field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_UPDATE_TEMPERATURE")
+   field(ZNAM, "Updated")
+   field(ONAM, "Updated")
+   field(SCAN, "5 second")
+}
+
+# Analogue to Digital Converter Section
+record(ai, "$(P)$(R)ADCCalibrationZeroDegree_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_ADC_CALIBRATION_ZERO_DEGREE")
+   field(SCAN, "I/O Intr")
+}
+
+record(ai, "$(P)$(R)ADCCalibrationFortyDegree_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_ADC_CALIBRATION_FORTY_DEGREE")
+   field(SCAN, "I/O Intr")
+}
+
+# Digital to Analogue Converter Section
+record(ai, "$(P)$(R)DACCalibrationZeroDegree_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_DAC_CALIBRATION_ZERO_DEGREE")
+   field(SCAN, "I/O Intr")
+}
+
+record(ai, "$(P)$(R)DACCalibrationFortyDegree_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_DAC_CALIBRATION_FORTY_DEGREE")
+   field(SCAN, "I/O Intr")
+}
+
+################################################################################
+# Records related to pre amp gain
+#
 record(bo, "$(P)$(R)ToggleGain")
 {
    field(DTYP, "asynInt32")
@@ -129,6 +182,9 @@ record(bi, "$(P)$(R)ToggleGain_RBV")
    field(SCAN, "I/O Intr")
 }
 
+################################################################################
+# Records realted to the Field-programmable gate array
+# 
 record(bo, "$(P)$(R)ToggleFPGAComms")
 {
    field(DTYP, "asynInt32")
@@ -146,6 +202,9 @@ record(bi, "$(P)$(R)ToggleFPGAComms_RBV")
    field(SCAN, "I/O Intr")
 }
 
+################################################################################
+# Build info
+#  
 record(stringin, "$(P)$(R)BuildDate_RBV")
 {
    field(DTYP, "asynOctetRead")
@@ -153,34 +212,9 @@ record(stringin, "$(P)$(R)BuildDate_RBV")
    field(SCAN, "I/O Intr")
 }
 
-record(ai, "$(P)$(R)ADCCalibrationZeroDegree_RBV")
-{
-   field(DTYP, "asynInt32")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_ADC_CALIBRATION_ZERO_DEGREE")
-   field(SCAN, "I/O Intr")
-}
-
-record(ai, "$(P)$(R)ADCCalibrationFortyDegree_RBV")
-{
-   field(DTYP, "asynInt32")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_ADC_CALIBRATION_FORTY_DEGREE")
-   field(SCAN, "I/O Intr")
-}
-
-record(ai, "$(P)$(R)DACCalibrationZeroDegree_RBV")
-{
-   field(DTYP, "asynInt32")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_DAC_CALIBRATION_ZERO_DEGREE")
-   field(SCAN, "I/O Intr")
-}
-
-record(ai, "$(P)$(R)DACCalibrationFortyDegree_RBV")
-{
-   field(DTYP, "asynInt32")
-   field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_DAC_CALIBRATION_FORTY_DEGREE")
-   field(SCAN, "I/O Intr")
-}
-
+################################################################################
+# Override ADCore records for acquire settings
+#
 record(bo, "$(P)$(R)Acquire") {
    field(DISP, "1")
 }

--- a/pixciApp/Db/Pixci.template
+++ b/pixciApp/Db/Pixci.template
@@ -13,6 +13,7 @@ record(mbbo, "$(P)$(R)TriggerMode")
    field(TWVL, "2")
    field(THST, "Btn. Triggered")
    field(THVL, "3")
+   field(DISP, "1")
 }
 
 record(mbbi, "$(P)$(R)TriggerMode_RBV")
@@ -25,6 +26,7 @@ record(mbbi, "$(P)$(R)TriggerMode_RBV")
    field(TWVL, "2")
    field(THST, "Btn. Triggered")
    field(THVL, "3")
+   field(FLNK, "$(P)$(R)WriteEnabler")
 }
 
 record(bo, "$(P)$(R)SoftTrigger")
@@ -33,6 +35,7 @@ record(bo, "$(P)$(R)SoftTrigger")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_SOFT_TRIGGER")
    field(ZNAM, "Done")
    field(ONAM, "Trigger")
+   field(DISP, "1")
 }
 
 record(bo, "$(P)$(R)TriggerPolarity")
@@ -42,6 +45,7 @@ record(bo, "$(P)$(R)TriggerPolarity")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_TRIGGER_POLARITY")
    field(ZNAM, "Rising Edge")
    field(ONAM, "Falling Edge")
+   field(DISP, "1")
    info(autosaveFields, "VAL")
 }
 
@@ -52,6 +56,16 @@ record(bi, "$(P)$(R)TriggerPolarity_RBV")
    field(ZNAM, "Rising Edge")
    field(ONAM, "Falling Edge")
    field(SCAN, "I/O Intr")
+}
+
+record(dfanout, "$(P)$(R)WriteEnabler") {
+   field(DOL, "0")
+   field(OUTA, "$(P)$(R)WriteEnabler.DISV")
+   field(OUTB, "$(P)$(R)TriggerPolarity.DISP")
+   field(OUTC, "$(P)$(R)TriggerMode.DISP")
+   field(OUTD, "$(P)$(R)Acquire.DISP")
+   field(OUTE, "$(P)$(R)SoftTrigger.DISP")
+   field(OMSL, "closed_loop")
 }
 
 record(bo, "$(P)$(R)UpdateTemperature")
@@ -166,6 +180,9 @@ record(ai, "$(P)$(R)DACCalibrationFortyDegree_RBV")
    field(SCAN, "I/O Intr")
 }
 
+record(bo, "$(P)$(R)Acquire") {
+   field(DISP, "1")
+}
 
 record(ai, "$(P)$(R)AcquireTime_RBV")
 {

--- a/pixciApp/Db/Pixci.template
+++ b/pixciApp/Db/Pixci.template
@@ -93,14 +93,13 @@ record(ai, "$(P)$(R)TemperaturePCB")
 }
 
 ################################################################################
-# TODO: check with Aoun about this record as the git blame shows that he wrote it
+# If this record is processed, the driver will update the PCB temperature, the 
+# actual temperature, and the maunfacturer information 
 #
 record(bo, "$(P)$(R)UpdateStatus")
 {
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_UPDATE_STATUS")
-   field(ZNAM, "Updated")
-   field(ONAM, "Updated")
 }
 
 ################################################################################
@@ -127,8 +126,6 @@ record(bo, "$(P)$(R)UpdateTemperature")
 {
    field(DTYP, "asynInt32")
    field(OUT,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))PR_UPDATE_TEMPERATURE")
-   field(ZNAM, "Updated")
-   field(ONAM, "Updated")
    field(SCAN, "5 second")
 }
 


### PR DESCRIPTION
- Add a record (WriteEnabler) that enables writing of PVs TriggerMode, TriggerPolarity, SoftTrigger, & Acquire.
- Set the default write mode of these PVs to disabled.
- The WriteEnabler record is processed when TriggerMode_RBV is first processed, and disables itself after it is processed once.
- Moved records in Pixci.template into sections with descriptions