### PR TITLE
88 make global variables for register definitions

### DIFF
--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -3,10 +3,6 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string>
-
 /* For windows */
 #if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__) || defined(__MINGW32__) || defined(__BORLANDC__)
 #include <windows.h>
@@ -45,6 +41,9 @@ using namespace std;
 #define BAUDRATE 115200
 
 #define SUCCESS_MESSAGE 0x50
+
+#define END_OF_TRANSMISSION_BYTE 0x50
+#define TRIGGER_MODE_BYTE 0xD4
 
 #define BINNING1 1
 #define BINNING2 2
@@ -598,8 +597,8 @@ void Pixci::paramTask()
 
     for (;;)
     {
-        paramMsgQue->receive(functionAndVal, 16);
-        function = (int)functionAndVal[0];
+        paramMsgQue->receive(functionAndVal, PARAM_MESSAGE_SIZE);
+        function = static_cast<epicsInt32>(functionAndVal[0]);
         val = functionAndVal[1];
         if (function == ADBinX)
         {
@@ -607,7 +606,7 @@ void Pixci::paramTask()
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinY, &binY);
-            status = Pixci::setBin(val, 0);
+            status = Pixci::setBin(val, BinAxisX);
             if (status == asynSuccess)
             {
                 setIntegerParam(ADBinX, val); // Updating the binX value.
@@ -687,9 +686,7 @@ void Pixci::paramTask()
             getIntegerParam(ADTriggerMode, &triggerMode);
             if (triggerMode == PR_BUTTON_TRIGGER)
             {
-                char reg = 0xD4;
-                char hexval = 0x01;
-                status = Pixci::writeSerialRegister(UNIT, reg, hexval);
+                status = Pixci::sendSoftTrigger();
             }
             else
             {
@@ -1499,8 +1496,8 @@ void Pixci::resetVideoSettings()
         pxd_videoFormatAsIncluded(0);
     }
 
-    setBin(binX, 0);
-    setBin(binY, 1);
+    setBin(binX, BinAxisX);
+    setBin(binY, BinAxisY);
     reloadVideoSettings();
 }
 
@@ -1620,7 +1617,7 @@ asynStatus Pixci::setBin(int val, bool coordinate)
         break;
     }
 
-    if (coordinate == false)
+    if (coordinate == BinAxisX)
     {
         reg = 0xA1;
     }
@@ -1779,7 +1776,7 @@ unsigned char Pixci::getSystemStatus()
     char cval = 0;
     char inputMsg[2];
     int inSize;
-    char first_bufout[] = {0x49, 0x50};
+    char first_bufout[] = {0x49, END_OF_TRANSMISSION_BYTE};
 
     /*writing to serial connection*/
     inSize = writeReadSerial(UNIT, first_bufout, sizeof(first_bufout), inputMsg, 2);
@@ -1799,7 +1796,7 @@ asynStatus Pixci::setSystemStatus(char val)
     char inputMsg[1];
 
     /* template of message to write value to registers */
-    char bufout[] = {0x4F, 0x00, 0x50};
+    char bufout[] = {0x4F, 0x00, END_OF_TRANSMISSION_BYTE};
     bufout[1] = val;
 
     /*writing to serial connection*/
@@ -2037,10 +2034,9 @@ asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
     asynStatus status;
     int inSize;
     char inputMsg[20];
-    unsigned char success = 0x50;
 
     /* template of message to write value to registers */
-    char bufout[] = {0x53, 0xE0, 0x02, 0x00, 0x00, 0x50};
+    char bufout[] = {0x53, 0xE0, 0x02, 0x00, 0x00, END_OF_TRANSMISSION_BYTE};
     bufout[3] = Register;
     bufout[4] = val;
 
@@ -2052,7 +2048,7 @@ asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
         return asynError;
     }
 
-    if (inputMsg[0] == success)
+    if (inputMsg[0] == SUCCESS_MESSAGE)
     {
         return asynSuccess;
     }
@@ -2063,8 +2059,8 @@ asynStatus Pixci::readSerialRegister(char Register, char *val)
 {
     char inputMsg[20];
     int inSize;
-    char first_bufout[] = {0x53, 0xE0, 0x01, 0xFF, 0x50};
-    char last_bufout[] = {0x53, 0xE1, 0x01, 0x50};
+    char first_bufout[] = {0x53, 0xE0, 0x01, 0xFF, END_OF_TRANSMISSION_BYTE};
+    char last_bufout[] = {0x53, 0xE1, 0x01, END_OF_TRANSMISSION_BYTE};
     first_bufout[3] = Register;
 
     /*writing to serial connection*/
@@ -2083,8 +2079,8 @@ asynStatus Pixci::readSerialRegister(char Register1, char Register2, char *val)
 {
     char inputMsg[20];
     int inSize;
-    char first_bufout[] = {0x53, 0xE0, 0x02, 0xFF, 0xFF, 0x50};
-    char last_bufout[] = {0x53, 0xE1, 0x01, 0x50};
+    char first_bufout[] = {0x53, 0xE0, 0x02, 0xFF, 0xFF, END_OF_TRANSMISSION_BYTE};
+    char last_bufout[] = {0x53, 0xE1, 0x01, END_OF_TRANSMISSION_BYTE};
     first_bufout[3] = Register1;
     first_bufout[4] = Register2;
 
@@ -2102,7 +2098,6 @@ asynStatus Pixci::readSerialRegister(char Register1, char Register2, char *val)
 
 asynStatus Pixci::setTriggerMode(int mode)
 {
-    char reg = 0xD4;
     char hexval;
     switch (mode)
     {
@@ -2132,7 +2127,13 @@ asynStatus Pixci::setTriggerMode(int mode)
         return asynError;
         break;
     }
-    return Pixci::writeSerialRegister(UNIT, reg, hexval);
+    return Pixci::writeSerialRegister(UNIT, TRIGGER_MODE_BYTE, hexval);
+}
+
+asynStatus Pixci::sendSoftTrigger()
+{
+    char hexval = 0x01;
+    return Pixci::writeSerialRegister(UNIT, TRIGGER_MODE_BYTE, hexval);
 }
 
 // PV Updating Functions
@@ -2155,8 +2156,8 @@ asynStatus Pixci::updateManufacturersData(bool callBackFlag)
 
     char inputMsg[20];
     int inSize;
-    char first_bufout[] = {0x53, 0xAE, 0x05, 0x01, 0x00, 0x00, 0x02, 0x00, 0x50};
-    char last_bufout[] = {0x53, 0xAF, 0x12, 0x50};
+    char first_bufout[] = {0x53, 0xAE, 0x05, 0x01, 0x00, 0x00, 0x02, 0x00, END_OF_TRANSMISSION_BYTE};
+    char last_bufout[] = {0x53, 0xAF, 0x12, END_OF_TRANSMISSION_BYTE};
 
     INT16 serialNumber = 0;
     string buildDate = "";

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -133,8 +133,8 @@ _cDcl(_dllpxlib, _cfunfcc, int)
         int voffset  // video voffset
     )
 {
-    int r = 0, r1;
-    int u, umap, multiple = 0;
+    int r = 0, r1 = 0;
+    int u = 0, umap = 0, multiple = 0;
     struct xclibs *xc;
 
 #if USEINTERNALAPI
@@ -575,7 +575,9 @@ void Pixci::paramTask()
         d_val = functionAndVal[1];
         if (function == ADBinX)
         {
-            epicsInt32 sizeX, sizeY, binY;
+            epicsInt32 sizeX = 0;
+            epicsInt32 sizeY = 0; 
+            epicsInt32 binY = 0;
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinY, &binY);
@@ -597,7 +599,9 @@ void Pixci::paramTask()
         }
         else if (function == ADBinY)
         {
-            epicsInt32 sizeX, sizeY, binX;
+            epicsInt32 sizeX = 0;
+            epicsInt32 sizeY = 0; 
+            epicsInt32 binX = 0;
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinX, &binX);
@@ -619,8 +623,8 @@ void Pixci::paramTask()
         }
         else if (function == ADTriggerMode)
         {
-            int acquisitionStatus;
-            int previousTriggerMode;
+            int acquisitionStatus = asynSuccess;
+            int previousTriggerMode = 0;
             status = setTriggerMode(i_val);
             if (status == asynSuccess)
             {
@@ -655,7 +659,7 @@ void Pixci::paramTask()
         else if (function == PR_SoftTrigger)
         {
             /* if trigger mode is button trigger then, do the soft trigger else print error */
-            int triggerMode;
+            int triggerMode = 0;
             getIntegerParam(ADTriggerMode, &triggerMode);
             if (triggerMode == PR_BUTTON_TRIGGER)
             {
@@ -681,8 +685,7 @@ void Pixci::paramTask()
                 status = setFrameRate(1 / d_val);
                 if (status == asynSuccess)
                 {
-                    double readBackFrameRate;
-                    readBackFrameRate = getFrameRate();
+                    double readBackFrameRate= getFrameRate();
                     if (readBackFrameRate > 0)
                     {
                         setDoubleParam(ADAcquirePeriod, (1 / readBackFrameRate));
@@ -730,8 +733,7 @@ void Pixci::paramTask()
                 status = setExposure(d_val);
                 if (status == asynSuccess)
                 {
-                    double readBackAcquireTime;
-                    readBackAcquireTime = getExposure();
+                    double readBackAcquireTime = getExposure(); 
                     if (readBackAcquireTime > 0)
                     {
                         setDoubleParam(ADAcquireTime, readBackAcquireTime);
@@ -2093,7 +2095,7 @@ asynStatus Pixci::setTriggerMode(int mode)
         hexval = INTERNAL_FFR_BYTE; // 00000110
         break;
     case PR_EXTERNAL:
-        int triggerPolarity;
+        int triggerPolarity = PR_EXT_RISING_EDGE;
         getIntegerParam(PR_TriggerPolarity, &triggerPolarity);
         if (triggerPolarity == PR_EXT_FALLING_EDGE)
         {

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -397,9 +397,12 @@ Pixci::~Pixci()
 
 asynStatus Pixci::setupAquisition()
 {
-    int binX, binY, sizeX, sizeY, RoiSizeX, RoiSizeY;
-    sizeX = pxd_imageXdim();
-    sizeY = pxd_imageYdim();
+    int binX = 0; 
+    int binY = 0; 
+    int RoiSizeX = 0; 
+    int RoiSizeY = 0;
+    int sizeX = pxd_imageXdim();
+    int sizeY = pxd_imageYdim();
     callParamCallbacks();
     getIntegerParam(ADBinX, &binX);
     if (binX <= 0)
@@ -432,10 +435,9 @@ asynStatus Pixci::acquireImage()
 
     /* TODO: implement all acquisition method like trigger, ringbuffer etc */
     static const char *functionName = "acquireImage";
-    int error;
     pxbuffer_t buffer = 1L; // Image frame buffer
     /* live capture the image into frame buffer */
-    error = pxd_goLive(UNIT, buffer);
+    int error = pxd_goLive(UNIT, buffer);
     if (error < NOERROR)
     {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
@@ -453,9 +455,8 @@ asynStatus Pixci::acquireImage()
 asynStatus Pixci::acquireStop()
 {
     static const char *functionName = "acquireStop";
-    int error;
     /* stop the live capturing */
-    error = pxd_goUnLive(UNIT);
+    int error = pxd_goUnLive(UNIT);
     if (error < NOERROR)
     {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
@@ -483,17 +484,18 @@ static void acquireTaskC(void *drvPvt)
 void Pixci::acquireTask()
 {
     /* TODO: need to implement in a seperate file */
-    NDArray *pImage;
+    NDArray *pImage = this->pArrays[0];
     pxbuffer_t buf = 1L;
-    pImage = this->pArrays[0];
-    NDDataType_t dataType;
-    epicsInt32 sizeX, sizeY;
-    epicsInt32 binX, binY;
+    NDDataType_t dataType = NDUInt16;
+    epicsInt32 sizeX = 0;
+    epicsInt32 sizeY = 0;
+    epicsInt32 binX = 0;
+    epicsInt32 binY = 0;
     size_t dims[2] = {};
-    epicsTimeStamp currentTime;
-    epicsInt32 numImagesCounter;
-    epicsInt32 imageCounter;
-    epicsInt32 arrayCallbacks;
+    epicsTimeStamp currentTime = {};
+    epicsInt32 numImagesCounter = 0;
+    epicsInt32 imageCounter = 0;
+    epicsInt32 arrayCallbacks = 0;
     setupAquisition();
 
     for (;;)
@@ -510,7 +512,6 @@ void Pixci::acquireTask()
 
         dims[0] = sizeX;
         dims[1] = sizeY;
-        dataType = NDUInt16;
 
         if (arrayCallbacks)
         {
@@ -560,11 +561,11 @@ static void paramTaskC(void *drvPvt)
 void Pixci::paramTask()
 {
     epicsFloat64 functionAndVal[2] = {};
-    epicsInt32 function;
-    epicsFloat64 d_val;
-    epicsInt32 i_val;
-    asynStatus status;
-    epicsInt32 acquire;
+    epicsInt32 function = 0;
+    epicsFloat64 d_val = 0.0;
+    epicsInt32 i_val = 0;
+    asynStatus status = asynSuccess;
+    epicsInt32 acquire = 0;
 
     for (;;)
     {
@@ -740,14 +741,18 @@ void Pixci::paramTask()
         }
         else if (function == ADMinX)
         {
-            epicsInt32 maxSizeX, minX, sizeX, sizeY, binX, binY;
+            epicsInt32 maxSizeX = 0;
+            epicsInt32 sizeX = 0;
+            epicsInt32 sizeY = 0;
+            epicsInt32 binX = 0;
+            epicsInt32 binY = 0;
             getIntegerParam(ADMaxSizeX, &maxSizeX);
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            minX = (i_val > maxSizeX) ? maxSizeX : i_val;
+            epicsInt32 minX = (i_val > maxSizeX) ? maxSizeX : i_val;
             if ((sizeX + minX) > maxSizeX)
             {
                 sizeX = maxSizeX - minX;
@@ -769,14 +774,18 @@ void Pixci::paramTask()
         }
         else if (function == ADMinY)
         {
-            epicsInt32 maxSizeY, minY, sizeY, sizeX, binX, binY;
+            epicsInt32 maxSizeY = 0;
+            epicsInt32 sizeX = 0;
+            epicsInt32 sizeY = 0;
+            epicsInt32 binX = 0;
+            epicsInt32 binY = 0;
             getIntegerParam(ADMaxSizeY, &maxSizeY);
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            minY = (i_val > maxSizeY) ? maxSizeY : i_val;
+            epicsInt32 minY = (i_val > maxSizeY) ? maxSizeY : i_val;
             if ((sizeY + minY) > maxSizeY)
             {
                 sizeY = maxSizeY - minY;
@@ -800,14 +809,18 @@ void Pixci::paramTask()
         }
         else if (function == ADSizeX)
         {
-            epicsInt32 maxSizeX, minX, sizeX, sizeY, binX, binY;
+            epicsInt32 maxSizeX = 0;
+            epicsInt32 minX = 0;
+            epicsInt32 sizeY = 0;
+            epicsInt32 binX = 0;
+            epicsInt32 binY = 0;
             getIntegerParam(ADMaxSizeX, &maxSizeX);
             getIntegerParam(ADMinX, &minX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            sizeX = (i_val > maxSizeX) ? maxSizeX : i_val;
+            epicsInt32 sizeX = (i_val > maxSizeX) ? maxSizeX : i_val;
 
             if ((sizeX + minX) > maxSizeX)
             {
@@ -832,14 +845,18 @@ void Pixci::paramTask()
         }
         else if (function == ADSizeY)
         {
-            epicsInt32 maxSizeY, minY, sizeY, sizeX, binX, binY;
+            epicsInt32 maxSizeY = 0;
+            epicsInt32 minY = 0;
+            epicsInt32 sizeX = 0;
+            epicsInt32 binX = 0;
+            epicsInt32 binY = 0;
             getIntegerParam(ADMaxSizeY, &maxSizeY);
             getIntegerParam(ADMinY, &minY);
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            sizeY = (i_val > maxSizeY) ? maxSizeY : i_val;
+            epicsInt32 sizeY = (i_val > maxSizeY) ? maxSizeY : i_val;
 
             if ((sizeY + minY) > maxSizeY)
             {
@@ -863,7 +880,7 @@ void Pixci::paramTask()
         }
         else if (function == PR_TriggerPolarity)
         {
-            int triggerMode;
+            int triggerMode = PR_INTERNAL_ITR;
             if (i_val == PR_EXT_RISING_EDGE)
             {
                 setIntegerParam(PR_TriggerPolarity, PR_EXT_RISING_EDGE);
@@ -885,8 +902,8 @@ void Pixci::paramTask()
 
 void Pixci::reloadVideoSettings()
 {
-    epicsInt32 sizeX;
-    epicsInt32 sizeY;
+    epicsInt32 sizeX = 0;
+    epicsInt32 sizeY = 0;
     getIntegerParam(ADBinX, &sizeX);
     getIntegerParam(ADBinY, &sizeY);
 
@@ -1452,7 +1469,8 @@ void Pixci::reloadVideoSettings()
 
 void Pixci::resetVideoSettings()
 {
-    epicsInt32 binX, binY;
+    epicsInt32 binX = 0;
+    epicsInt32 binY = 0;
     getIntegerParam(ADBinX, &binX);
     getIntegerParam(ADBinY, &binY);
     if (cameraModel == DETECTOR_2048)
@@ -1495,7 +1513,7 @@ void Pixci::epicsUInt64ToUChar(epicsUInt64 lval, char *cval)
 
 int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *serialIn, int serialInBufferSize)
 {
-    int count, i;
+    int count = 0;
     char bufOut[50] = {};
     char chkSum = 0;
     int outMsgwait = 0;
@@ -1517,7 +1535,7 @@ int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *seri
     outMsgwait = 0;
 
     /* creating checksum to send as the last character of the message */
-    for (i = 0; i < msgOutSize; i++)
+    for (int i = 0; i < msgOutSize; i++)
     {
         bufOut[i] = serialOut[i];
         chkSum ^= serialOut[i];
@@ -1528,7 +1546,7 @@ int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *seri
     count = pxd_serialWrite(unit, RESERVED, serialOut, msgOutSize + 1);
     Sleep(130);
 
-    if (count < ERROR)
+    if (count < NOERROR)
     {
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR,
                   "%s: Cannot serial write: %s.",
@@ -1857,7 +1875,7 @@ asynStatus Pixci::writeInt32(asynUser *pasynUser, epicsInt32 value)
             the trigger mode is changed from button trigger mode, the actual implementation
             of acquireStop() will be done.
             */
-            int triggerMode;
+            int triggerMode = PR_INTERNAL_ITR;
             getIntegerParam(ADTriggerMode, &triggerMode);
             if (triggerMode == PR_BUTTON_TRIGGER)
             {
@@ -2006,7 +2024,7 @@ asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
 asynStatus Pixci::readSerialRegister(char Register, char *val)
 {
     char inputMsg[20] = {};
-    int inSize;
+    int inSize = 0;
     char first_bufout[] = {
          static_cast<char>(SINGLE_OUTPUT_BYTE_PREFIX_BYTES[0]), 
          static_cast<char>(SINGLE_OUTPUT_BYTE_PREFIX_BYTES[1]), 
@@ -2036,7 +2054,7 @@ asynStatus Pixci::readSerialRegister(char Register, char *val)
 asynStatus Pixci::readSerialRegister(char Register1, char Register2, char *val)
 {
     char inputMsg[20] = {};
-    int inSize;
+    int inSize = 0;
     char first_bufout[] = {
          static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0]), 
          static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[1]), 
@@ -2065,7 +2083,7 @@ asynStatus Pixci::readSerialRegister(char Register1, char Register2, char *val)
 
 asynStatus Pixci::setTriggerMode(int mode)
 {
-    char hexval;
+    char hexval = 0;
     switch (mode)
     {
     case PR_INTERNAL_ITR:
@@ -2115,7 +2133,7 @@ void Pixci::updateTemperaturePcb(bool callBackFlag)
 asynStatus Pixci::updateManufacturersData(bool callBackFlag)
 {
     char inputMsg[20] = {};
-    int inSize;
+    int inSize = 0;
     char first_bufout[] = {
          static_cast<char>(GET_MISC_DATA_BYTES[0]), 
          static_cast<char>(GET_MISC_DATA_BYTES[1]), 
@@ -2205,8 +2223,7 @@ asynStatus Pixci::updateIntialPVs()
 {
     epicsInt32 sizeX = pxd_imageXdim();
     epicsInt32 sizeY = pxd_imageYdim();
-    epicsFloat64 acquireFrameRate;
-    acquireFrameRate = getFrameRate();
+    epicsFloat64 acquireFrameRate = getFrameRate();
     asynStatus status = asynSuccess;
 
     setStatIfHigher(status, setIntegerParam(ADMaxSizeX, sizeX));
@@ -2324,7 +2341,9 @@ void Pixci::report(FILE *fp, int details)
     fprintf(fp, "Raptor detector %s\n", this->portName);
     if (details > 0)
     {
-        int nx, ny, dataType;
+        int nx = 0;
+        int ny = 0;
+        int dataType = 0;
         getIntegerParam(ADSizeX, &nx);
         getIntegerParam(ADSizeY, &ny);
         getIntegerParam(NDDataType, &dataType);

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -40,11 +40,6 @@ using namespace std;
 #define RESERVED 0
 #define BAUDRATE 115200
 
-#define SUCCESS_MESSAGE 0x50
-
-#define END_OF_TRANSMISSION_BYTE 0x50
-#define TRIGGER_MODE_BYTE 0xD4
-
 #define BINNING1 1
 #define BINNING2 2
 #define BINNING4 4
@@ -574,7 +569,7 @@ void Pixci::acquireTask()
         imageCounter++;
         numImagesCounter++;
 
-        setIntegerParam(NDArraySize, dims[0] * dims[1] * sizeof(NDUInt16));
+        setIntegerParam(NDArraySize, static_cast<int>(dims[0] * dims[1] * sizeof(NDUInt16)));
         setIntegerParam(NDArrayCounter, imageCounter);
         setIntegerParam(ADNumImagesCounter, numImagesCounter);
         callParamCallbacks();
@@ -591,7 +586,8 @@ void Pixci::paramTask()
 {
     epicsFloat64 functionAndVal[2];
     epicsInt32 function;
-    epicsFloat64 val;
+    epicsFloat64 d_val;
+    epicsInt32 i_val;
     asynStatus status;
     epicsInt32 acquire;
 
@@ -599,22 +595,23 @@ void Pixci::paramTask()
     {
         paramMsgQue->receive(functionAndVal, PARAM_MESSAGE_SIZE);
         function = static_cast<epicsInt32>(functionAndVal[0]);
-        val = functionAndVal[1];
+        i_val = static_cast<epicsInt32>(functionAndVal[1]);
+        d_val = functionAndVal[1];
         if (function == ADBinX)
         {
             epicsInt32 sizeX, sizeY, binY;
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinY, &binY);
-            status = Pixci::setBin(val, BinAxisX);
+            status = Pixci::setBin(i_val, BIN_AXIS_X);
             if (status == asynSuccess)
             {
-                setIntegerParam(ADBinX, val); // Updating the binX value.
+                setIntegerParam(ADBinX, i_val); // Updating the binX value.
                 callParamCallbacks();
                 getIntegerParam(ADAcquire, &acquire); // Getting the ADAcquire value.
                 reloadVideoSettings();                // Video settings have to be loaded respective of binning value.
                 acquireStop();                        // Acquire have to be stopped before calling setupAcquisition.
-                pxd_setVideoResolution(UNIT, sizeX / val, sizeY / binY, 0, 0);
+                pxd_setVideoResolution(UNIT, sizeX / i_val, sizeY / binY, 0, 0);
                 setupAquisition();
                 if (acquire == 1)
                 {
@@ -628,15 +625,15 @@ void Pixci::paramTask()
             getIntegerParam(ADSizeX, &sizeX);
             getIntegerParam(ADSizeY, &sizeY);
             getIntegerParam(ADBinX, &binX);
-            status = Pixci::setBin(val, 1);
+            status = Pixci::setBin(i_val, BIN_AXIS_Y);
             if (status == asynSuccess)
             {
-                setIntegerParam(ADBinY, val);
+                setIntegerParam(ADBinY, i_val);
                 callParamCallbacks();
                 getIntegerParam(ADAcquire, &acquire);
                 reloadVideoSettings();
                 acquireStop();
-                pxd_setVideoResolution(UNIT, sizeX / binX, sizeY / val, 0, 0);
+                pxd_setVideoResolution(UNIT, sizeX / binX, sizeY / i_val, 0, 0);
                 setupAquisition();
                 if (acquire == 1)
                 {
@@ -648,10 +645,10 @@ void Pixci::paramTask()
         {
             int acquisitionStatus;
             int previousTriggerMode;
-            status = setTriggerMode(val);
+            status = setTriggerMode(i_val);
             if (status == asynSuccess)
             {
-                if (val == PR_BUTTON_TRIGGER)
+                if (i_val == PR_BUTTON_TRIGGER)
                 {
                     /* In button triggermode, for WaitForSingleObject function to be notified pxd_goLive should be
                     called. For that acquireImage() function is called.
@@ -676,7 +673,7 @@ void Pixci::paramTask()
                         }
                     }
                 }
-                setIntegerParam(ADTriggerMode, val);
+                setIntegerParam(ADTriggerMode, i_val);
             }
         }
         else if (function == PR_SoftTrigger)
@@ -703,9 +700,9 @@ void Pixci::paramTask()
         }
         else if (function == ADAcquirePeriod)
         {
-            if (val != 0)
+            if (d_val != 0.0)
             {
-                status = setFrameRate(1 / val);
+                status = setFrameRate(1 / d_val);
                 if (status == asynSuccess)
                 {
                     double readBackFrameRate;
@@ -719,7 +716,7 @@ void Pixci::paramTask()
         }
         else if (function == ADTemperature)
         {
-            status = setTecTemperature(val);
+            status = setTecTemperature(d_val);
             if (status == asynSuccess)
             {
                 double tecTemperature = getTecTemperature();
@@ -728,7 +725,7 @@ void Pixci::paramTask()
         }
         else if (function == PR_ToggleTec)
         {
-            status = toggleTec(val);
+            status = toggleTec(i_val);
             if (status == asynSuccess)
             {
                 setIntegerParam(PR_ToggleTec, isTecEnabled());
@@ -736,7 +733,7 @@ void Pixci::paramTask()
         }
         else if (function == PR_ToggleGain)
         {
-            status = toggleGain(val);
+            status = toggleGain(i_val);
             if (status == asynSuccess)
             {
                 setIntegerParam(PR_ToggleGain, isGainEnabled());
@@ -744,7 +741,7 @@ void Pixci::paramTask()
         }
         else if (function == PR_ToggleFpgaComms)
         {
-            status = toggleFpgaComms(val);
+            status = toggleFpgaComms(i_val);
             if (status == asynSuccess)
             {
                 setIntegerParam(PR_ToggleFpgaComms, isFpgaCommsEnabled());
@@ -752,9 +749,9 @@ void Pixci::paramTask()
         }
         else if (function == ADAcquireTime)
         {
-            if (val != 0)
+            if (d_val != 0.0)
             {
-                status = setExposure(val);
+                status = setExposure(d_val);
                 if (status == asynSuccess)
                 {
                     double readBackAcquireTime;
@@ -775,7 +772,7 @@ void Pixci::paramTask()
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            minX = (val > maxSizeX) ? maxSizeX : val;
+            minX = (i_val > maxSizeX) ? maxSizeX : i_val;
             if ((sizeX + minX) > maxSizeX)
             {
                 sizeX = maxSizeX - minX;
@@ -804,7 +801,7 @@ void Pixci::paramTask()
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            minY = (val > maxSizeY) ? maxSizeY : val;
+            minY = (i_val > maxSizeY) ? maxSizeY : i_val;
             if ((sizeY + minY) > maxSizeY)
             {
                 sizeY = maxSizeY - minY;
@@ -835,7 +832,7 @@ void Pixci::paramTask()
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            sizeX = (val > maxSizeX) ? maxSizeX : val;
+            sizeX = (i_val > maxSizeX) ? maxSizeX : i_val;
 
             if ((sizeX + minX) > maxSizeX)
             {
@@ -843,7 +840,7 @@ void Pixci::paramTask()
             }
             acquireStop();
 
-            status == setRoiSizeX(sizeX);
+            status = setRoiSizeX(sizeX);
             status = setRoiOffsetX(minX);
             sizeX = getRoiSizeX();
             // status = setRoiSizeY(sizeY);
@@ -867,7 +864,7 @@ void Pixci::paramTask()
             getIntegerParam(ADBinX, &binX);
             getIntegerParam(ADBinY, &binY);
             getIntegerParam(ADAcquire, &acquire);
-            sizeY = (val > maxSizeY) ? maxSizeY : val;
+            sizeY = (i_val > maxSizeY) ? maxSizeY : i_val;
 
             if ((sizeY + minY) > maxSizeY)
             {
@@ -892,11 +889,11 @@ void Pixci::paramTask()
         else if (function == PR_TriggerPolarity)
         {
             int triggerMode;
-            if (val == PR_EXT_RISING_EDGE)
+            if (i_val == PR_EXT_RISING_EDGE)
             {
                 setIntegerParam(PR_TriggerPolarity, PR_EXT_RISING_EDGE);
             }
-            else if (val == PR_EXT_FALLING_EDGE)
+            else if (i_val == PR_EXT_FALLING_EDGE)
             {
                 setIntegerParam(PR_TriggerPolarity, PR_EXT_FALLING_EDGE);
             }
@@ -1496,8 +1493,8 @@ void Pixci::resetVideoSettings()
         pxd_videoFormatAsIncluded(0);
     }
 
-    setBin(binX, BinAxisX);
-    setBin(binY, BinAxisY);
+    setBin(binX, BIN_AXIS_X);
+    setBin(binY, BIN_AXIS_Y);
     reloadVideoSettings();
 }
 
@@ -1582,10 +1579,10 @@ int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *seri
     return count;
 }
 
-asynStatus Pixci::setBin(int val, bool coordinate)
+asynStatus Pixci::setBin(epicsInt32 val, epicsBoolean coordinate)
 {
     char hexval;
-    char reg;
+    char reg = (coordinate == BIN_AXIS_X) ? X_BIN_BYTE : Y_BIN_BYTE;
 
     /* Assigning corresponding Hex value to send*/
     switch (val)
@@ -1617,14 +1614,6 @@ asynStatus Pixci::setBin(int val, bool coordinate)
         break;
     }
 
-    if (coordinate == BinAxisX)
-    {
-        reg = 0xA1;
-    }
-    else
-    {
-        reg = 0xA2;
-    }
     return Pixci::writeSerialRegister(UNIT, reg, hexval);
 }
 
@@ -1636,24 +1625,23 @@ asynStatus Pixci::setFrameRate(double frameRate)
     frameRateCount = (unsigned long)(COUNT_PER_FRAME / frameRate);
     longTouchar(frameRateCount, frameRateHexVal);
 
-    writeSerialRegister(UNIT, 0xDC, frameRateHexVal[0]);
-    writeSerialRegister(UNIT, 0xDD, frameRateHexVal[1]);
-    writeSerialRegister(UNIT, 0xDE, frameRateHexVal[2]);
-    writeSerialRegister(UNIT, 0xDF, frameRateHexVal[3]);
-    return writeSerialRegister(UNIT, 0xE0, frameRateHexVal[4]);
+    writeSerialRegister(UNIT, FRAME_RATE_BYTES[0], frameRateHexVal[0]);
+    writeSerialRegister(UNIT, FRAME_RATE_BYTES[1], frameRateHexVal[1]);
+    writeSerialRegister(UNIT, FRAME_RATE_BYTES[2], frameRateHexVal[2]);
+    writeSerialRegister(UNIT, FRAME_RATE_BYTES[3], frameRateHexVal[3]);
+    return writeSerialRegister(UNIT, FRAME_RATE_BYTES[4], frameRateHexVal[4]);
 }
 
 double Pixci::getFrameRate()
 {
     char cval[5] = {0, 0, 0, 0, 0};
     double frameRate = 0.0;
-    asynStatus status;
     unsigned long long frameRateCount = 0;
-    readSerialRegister(0XDC, &cval[0]);
-    readSerialRegister(0xDD, &cval[1]);
-    readSerialRegister(0xDE, &cval[2]);
-    readSerialRegister(0XDF, &cval[3]);
-    readSerialRegister(0XE0, &cval[4]);
+    readSerialRegister(FRAME_RATE_BYTES[0], &cval[0]);
+    readSerialRegister(FRAME_RATE_BYTES[1], &cval[1]);
+    readSerialRegister(FRAME_RATE_BYTES[2], &cval[2]);
+    readSerialRegister(FRAME_RATE_BYTES[3], &cval[3]);
+    readSerialRegister(FRAME_RATE_BYTES[4], &cval[4]);
 
     frameRateCount = UcharToLong(cval);
     if (frameRateCount > 0)
@@ -1682,8 +1670,8 @@ double Pixci::getTemperatureActual()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(0X6E, 0x00, &cval[0]);
-    readSerialRegister(0X6F, 0x00, &cval[1]);
+    readSerialRegister(CCD_SILISCON_TEMPERATURE_BYTES[0], 0x00, &cval[0]);
+    readSerialRegister(CCD_SILISCON_TEMPERATURE_BYTES[1], 0x00, &cval[1]);
 
     INT16 adcCount = 0;
     adcCount += (INT16)(unsigned char)cval[1];
@@ -1696,8 +1684,8 @@ double Pixci::getTemperaturePcb()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(0X70, 0x00, &cval[1]);
-    readSerialRegister(0X71, 0x00, &cval[0]);
+    readSerialRegister(PCB_TEMPERATURE_BYTES[0], 0x00, &cval[1]);
+    readSerialRegister(PCB_TEMPERATURE_BYTES[1], 0x00, &cval[0]);
 
     INT16 lval = 0;
     lval += (INT16)(unsigned char)cval[0];
@@ -1711,8 +1699,8 @@ double Pixci::getTecTemperature()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(0X03, &cval[1]);
-    readSerialRegister(0X04, &cval[0]);
+    readSerialRegister(TEC_TEMPERATURE_BYTES[0], &cval[1]);
+    readSerialRegister(TEC_TEMPERATURE_BYTES[1], &cval[0]);
 
     INT16 lval = 0;
     lval += (INT16)(unsigned char)cval[0];

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -261,8 +261,6 @@ static void acquireTaskC(void *drvPvt);
 // static void serialTaskC(void *drvPvt);
 static void paramTaskC(void *drvPvt);
 
-/* Event handler for acquire task */
-HANDLE g_hEvent;
 /*
  * @brief Configuration command for pixci driver; creates a new pixci object.
  * @param See the pixci.h

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -1474,18 +1474,18 @@ void Pixci::resetVideoSettings()
     reloadVideoSettings();
 }
 
-unsigned long long Pixci::UcharToLong(char *cval)
+epicsInt64 Pixci::uCharToEpicsUInt64(char *cval)
 {
-    unsigned long long lval = 0;
-    lval += (unsigned long)(unsigned char)cval[4];
-    lval += ((unsigned long)(unsigned char)cval[3]) << 8;
-    lval += ((unsigned long)(unsigned char)cval[2]) << 16;
-    lval += ((unsigned long)(unsigned char)cval[1]) << 24;
-    lval += ((unsigned long)(unsigned char)cval[0]) << 32;
+    epicsInt64 lval = 0;
+    lval += (epicsUInt64)(epicsUInt8)cval[4];
+    lval += ((epicsUInt64)(epicsUInt8)cval[3]) << 8;
+    lval += ((epicsUInt64)(epicsUInt8)cval[2]) << 16;
+    lval += ((epicsUInt64)(epicsUInt8)cval[1]) << 24;
+    lval += ((epicsUInt64)(epicsUInt8)cval[0]) << 32;
     return lval;
 }
 
-void Pixci::longTouchar(long lval, char *cval)
+void Pixci::epicsUInt64ToUChar(epicsUInt64 lval, char *cval)
 {
     cval[0] = (char)((lval & 0xFF00000000) >> 32);
     cval[1] = (char)((lval & 0x00FF000000) >> 24);
@@ -1595,11 +1595,10 @@ asynStatus Pixci::setBin(epicsInt32 val, epicsBoolean coordinate)
 
 asynStatus Pixci::setFrameRate(double frameRate)
 {
-    unsigned long frameRateCount;
-    unsigned long long lval;
+    epicsUInt64 frameRateCount;
     char frameRateHexVal[5] = {0, 0, 0, 0, 0};
-    frameRateCount = (unsigned long)(COUNT_PER_FRAME / frameRate);
-    longTouchar(frameRateCount, frameRateHexVal);
+    frameRateCount = (epicsUInt64)(COUNT_PER_FRAME / frameRate);
+    epicsUInt64ToUChar(frameRateCount, frameRateHexVal);
 
     writeSerialRegister(UNIT, FRAME_RATE_BYTES[0], frameRateHexVal[0]);
     writeSerialRegister(UNIT, FRAME_RATE_BYTES[1], frameRateHexVal[1]);
@@ -1619,7 +1618,7 @@ double Pixci::getFrameRate()
     readSerialRegister(FRAME_RATE_BYTES[3], &cval[3]);
     readSerialRegister(FRAME_RATE_BYTES[4], &cval[4]);
 
-    frameRateCount = UcharToLong(cval);
+    frameRateCount = uCharToEpicsUInt64(cval);
     if (frameRateCount > 0)
     {
         frameRate = 40e6 / double(frameRateCount);
@@ -1634,7 +1633,7 @@ double Pixci::convertAdcCountToCentigrade(INT16 adcCount)
 
 INT16 Pixci::convertCentigradeToDacCount(double temperature)
 {
-    return (temperature - DAC_C) / DAC_M;
+    return static_cast<INT16>((temperature - DAC_C) / DAC_M);
 }
 
 double Pixci::convertDacCountToCentigrade(INT16 dacCount)
@@ -1793,11 +1792,10 @@ bool Pixci::isFpgaCommsEnabled()
 
 asynStatus Pixci::setExposure(double exposureTime)
 {
-    unsigned long exposureTimeCount;
-    unsigned long long lval;
+    epicsUInt64 exposureTimeCount;
     char exposureTimeHexVal[5] = {0, 0, 0, 0, 0};
-    exposureTimeCount = (unsigned long)(exposureTime * EXPOSURE_COUNT_TO_TIME / SEC_TO_mS);
-    longTouchar(exposureTimeCount, exposureTimeHexVal);
+    exposureTimeCount = (epicsUInt64)(exposureTime * EXPOSURE_COUNT_TO_TIME / SEC_TO_mS);
+    epicsUInt64ToUChar(exposureTimeCount, exposureTimeHexVal);
 
     writeSerialRegister(UNIT, EXPOSURE_BYTES[0], exposureTimeHexVal[0]);
     writeSerialRegister(UNIT, EXPOSURE_BYTES[1], exposureTimeHexVal[1]);
@@ -1817,7 +1815,7 @@ double Pixci::getExposure()
     readSerialRegister(EXPOSURE_BYTES[3], &cval[3]);
     readSerialRegister(EXPOSURE_BYTES[4], &cval[4]);
 
-    exposureTimeCount = UcharToLong(cval);
+    exposureTimeCount = uCharToEpicsUInt64(cval);
     if (exposureTimeCount > 0)
     {
         exposureTime = (double(exposureTimeCount) / EXPOSURE_COUNT_TO_TIME) * SEC_TO_mS;
@@ -1991,15 +1989,14 @@ void Pixci::addToParamQue(epicsInt32 function, epicsFloat64 value)
 
 asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
 {
-    asynStatus status;
     int inSize;
     char inputMsg[20];
 
     /* template of message to write value to registers */
     char bufout[] = {
-        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0], 
-        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[1], 
-        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[2], 
+        static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0]), 
+        static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[1]), 
+        static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[2]), 
         Register, val, 
         END_OF_TRANSMISSION_BYTE
     };
@@ -2024,16 +2021,16 @@ asynStatus Pixci::readSerialRegister(char Register, char *val)
     char inputMsg[20];
     int inSize;
     char first_bufout[] = {
-        SINGLE_OUTPUT_BYTE_PREFIX_BYTES[0], 
-        SINGLE_OUTPUT_BYTE_PREFIX_BYTES[1], 
-        SINGLE_OUTPUT_BYTE_PREFIX_BYTES[2], 
+         static_cast<char>(SINGLE_OUTPUT_BYTE_PREFIX_BYTES[0]), 
+         static_cast<char>(SINGLE_OUTPUT_BYTE_PREFIX_BYTES[1]), 
+         static_cast<char>(SINGLE_OUTPUT_BYTE_PREFIX_BYTES[2]), 
         Register, 
         END_OF_TRANSMISSION_BYTE
     };
     char last_bufout[] = {
-        READ_SERIAL_PREFIX_BYTES[0], 
-        READ_SERIAL_PREFIX_BYTES[1], 
-        READ_SERIAL_PREFIX_BYTES[2], 
+         static_cast<char>(READ_SERIAL_PREFIX_BYTES[0]), 
+         static_cast<char>(READ_SERIAL_PREFIX_BYTES[1]), 
+         static_cast<char>(READ_SERIAL_PREFIX_BYTES[2]), 
         END_OF_TRANSMISSION_BYTE
     };
 
@@ -2054,16 +2051,16 @@ asynStatus Pixci::readSerialRegister(char Register1, char Register2, char *val)
     char inputMsg[20];
     int inSize;
     char first_bufout[] = {
-        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0], 
-        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[1], 
-        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[2], 
+         static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0]), 
+         static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[1]), 
+         static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[2]), 
         Register1, Register2, 
         END_OF_TRANSMISSION_BYTE
     };
     char last_bufout[] = {
-        READ_SERIAL_PREFIX_BYTES[0], 
-        READ_SERIAL_PREFIX_BYTES[1], 
-        READ_SERIAL_PREFIX_BYTES[2], 
+         static_cast<char>(READ_SERIAL_PREFIX_BYTES[0]), 
+         static_cast<char>(READ_SERIAL_PREFIX_BYTES[1]), 
+         static_cast<char>(READ_SERIAL_PREFIX_BYTES[2]), 
         END_OF_TRANSMISSION_BYTE
     };
 
@@ -2135,24 +2132,23 @@ void Pixci::updateTemperaturePcb(bool callBackFlag)
 
 asynStatus Pixci::updateManufacturersData(bool callBackFlag)
 {
-
     char inputMsg[20];
     int inSize;
     char first_bufout[] = {
-        GET_MISC_DATA_BYTES[0], 
-        GET_MISC_DATA_BYTES[1], 
-        GET_MISC_DATA_BYTES[2], 
-        GET_MISC_DATA_BYTES[3], 
-        GET_MISC_DATA_BYTES[4], 
-        GET_MISC_DATA_BYTES[5], 
-        GET_MISC_DATA_BYTES[6], 
-        GET_MISC_DATA_BYTES[7], 
+         static_cast<char>(GET_MISC_DATA_BYTES[0]), 
+         static_cast<char>(GET_MISC_DATA_BYTES[1]), 
+         static_cast<char>(GET_MISC_DATA_BYTES[2]), 
+         static_cast<char>(GET_MISC_DATA_BYTES[3]), 
+         static_cast<char>(GET_MISC_DATA_BYTES[4]), 
+         static_cast<char>(GET_MISC_DATA_BYTES[5]), 
+         static_cast<char>(GET_MISC_DATA_BYTES[6]), 
+         static_cast<char>(GET_MISC_DATA_BYTES[7]), 
         END_OF_TRANSMISSION_BYTE
     };
     char last_bufout[] = {
-        MANUFACTURER_DATA_BYTES[0], 
-        MANUFACTURER_DATA_BYTES[1], 
-        MANUFACTURER_DATA_BYTES[2], 
+         static_cast<char>(MANUFACTURER_DATA_BYTES[0]), 
+         static_cast<char>(MANUFACTURER_DATA_BYTES[1]), 
+         static_cast<char>(MANUFACTURER_DATA_BYTES[2]), 
         END_OF_TRANSMISSION_BYTE
     };
 

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -1474,9 +1474,9 @@ void Pixci::resetVideoSettings()
     reloadVideoSettings();
 }
 
-epicsInt64 Pixci::uCharToEpicsUInt64(char *cval)
+epicsUInt64 Pixci::uCharToEpicsUInt64(char *cval)
 {
-    epicsInt64 lval = 0;
+    epicsUInt64 lval = 0;
     lval += (epicsUInt64)(epicsUInt8)cval[4];
     lval += ((epicsUInt64)(epicsUInt8)cval[3]) << 8;
     lval += ((epicsUInt64)(epicsUInt8)cval[2]) << 16;
@@ -1498,7 +1498,7 @@ int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *seri
 {
     int count, i;
     char bufOut[50];
-    char chkSum;
+    char chkSum = 0;
     int outMsgwait = 0;
     int inMsgwait = 0;
     int inMsgwaitFlag = 0;
@@ -1535,7 +1535,6 @@ int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *seri
                   "%s: Cannot serial write: %s.",
                   driverName, pxd_mesgErrorCode(count));
         return count;
-        ;
     }
     else
     {
@@ -1557,7 +1556,7 @@ int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *seri
 
 asynStatus Pixci::setBin(epicsInt32 val, epicsBoolean coordinate)
 {
-    char hexval;
+    char hexval = 0;
     char reg = (coordinate == BIN_AXIS_X) ? X_BIN_BYTE : Y_BIN_BYTE;
 
     /* Assigning corresponding Hex value to send*/
@@ -1595,9 +1594,8 @@ asynStatus Pixci::setBin(epicsInt32 val, epicsBoolean coordinate)
 
 asynStatus Pixci::setFrameRate(double frameRate)
 {
-    epicsUInt64 frameRateCount;
     char frameRateHexVal[5] = {0, 0, 0, 0, 0};
-    frameRateCount = (epicsUInt64)(COUNT_PER_FRAME / frameRate);
+    epicsUInt64 frameRateCount = (epicsUInt64)(COUNT_PER_FRAME / frameRate);
     epicsUInt64ToUChar(frameRateCount, frameRateHexVal);
 
     writeSerialRegister(UNIT, FRAME_RATE_BYTES[0], frameRateHexVal[0]);
@@ -1611,14 +1609,13 @@ double Pixci::getFrameRate()
 {
     char cval[5] = {0, 0, 0, 0, 0};
     double frameRate = 0.0;
-    unsigned long long frameRateCount = 0;
     readSerialRegister(FRAME_RATE_BYTES[0], &cval[0]);
     readSerialRegister(FRAME_RATE_BYTES[1], &cval[1]);
     readSerialRegister(FRAME_RATE_BYTES[2], &cval[2]);
     readSerialRegister(FRAME_RATE_BYTES[3], &cval[3]);
     readSerialRegister(FRAME_RATE_BYTES[4], &cval[4]);
 
-    frameRateCount = uCharToEpicsUInt64(cval);
+    epicsUInt64 frameRateCount = uCharToEpicsUInt64(cval);
     if (frameRateCount > 0)
     {
         frameRate = 40e6 / double(frameRateCount);
@@ -1736,11 +1733,10 @@ unsigned char Pixci::getSystemStatus()
 {
     char cval = 0;
     char inputMsg[2];
-    int inSize;
     char first_bufout[] = {GET_SYSTEM_STATUS_BYTE, END_OF_TRANSMISSION_BYTE};
 
     /*writing to serial connection*/
-    inSize = writeReadSerial(UNIT, first_bufout, sizeof(first_bufout), inputMsg, 2);
+    int inSize = writeReadSerial(UNIT, first_bufout, sizeof(first_bufout), inputMsg, 2);
 
     if (inputMsg[1] == SUCCESS_MESSAGE)
     {
@@ -1753,14 +1749,13 @@ unsigned char Pixci::getSystemStatus()
 
 asynStatus Pixci::setSystemStatus(char val)
 {
-    int inSize;
     char inputMsg[1];
 
     /* template of message to write value to registers */
     char bufout[] = {SET_SYSTEM_STATUS_BYTE, val, END_OF_TRANSMISSION_BYTE};
 
     /*writing to serial connection*/
-    inSize = writeReadSerial(UNIT, bufout, sizeof(bufout), inputMsg, 1);
+    int inSize = writeReadSerial(UNIT, bufout, sizeof(bufout), inputMsg, 1);
 
     if (inSize < NOERROR)
     {
@@ -1792,9 +1787,8 @@ bool Pixci::isFpgaCommsEnabled()
 
 asynStatus Pixci::setExposure(double exposureTime)
 {
-    epicsUInt64 exposureTimeCount;
     char exposureTimeHexVal[5] = {0, 0, 0, 0, 0};
-    exposureTimeCount = (epicsUInt64)(exposureTime * EXPOSURE_COUNT_TO_TIME / SEC_TO_mS);
+    epicsUInt64 exposureTimeCount = (epicsUInt64)(exposureTime * EXPOSURE_COUNT_TO_TIME / SEC_TO_mS);
     epicsUInt64ToUChar(exposureTimeCount, exposureTimeHexVal);
 
     writeSerialRegister(UNIT, EXPOSURE_BYTES[0], exposureTimeHexVal[0]);
@@ -1808,14 +1802,13 @@ double Pixci::getExposure()
 {
     char cval[5] = {0, 0, 0, 0, 0};
     double exposureTime = 0.0;
-    unsigned long long exposureTimeCount = 0;
     readSerialRegister(EXPOSURE_BYTES[0], &cval[0]);
     readSerialRegister(EXPOSURE_BYTES[1], &cval[1]);
     readSerialRegister(EXPOSURE_BYTES[2], &cval[2]);
     readSerialRegister(EXPOSURE_BYTES[3], &cval[3]);
     readSerialRegister(EXPOSURE_BYTES[4], &cval[4]);
 
-    exposureTimeCount = uCharToEpicsUInt64(cval);
+    epicsUInt64 exposureTimeCount = uCharToEpicsUInt64(cval);
     if (exposureTimeCount > 0)
     {
         exposureTime = (double(exposureTimeCount) / EXPOSURE_COUNT_TO_TIME) * SEC_TO_mS;
@@ -1989,7 +1982,6 @@ void Pixci::addToParamQue(epicsInt32 function, epicsFloat64 value)
 
 asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
 {
-    int inSize;
     char inputMsg[20];
 
     /* template of message to write value to registers */
@@ -2002,7 +1994,7 @@ asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
     };
 
     /*writing to serial connection*/
-    inSize = writeReadSerial(UNIT, bufout, 6, inputMsg, 20);
+    int inSize = writeReadSerial(UNIT, bufout, 6, inputMsg, 20);
 
     if (inSize < NOERROR)
     {

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -1670,8 +1670,8 @@ double Pixci::getTemperatureActual()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(CCD_SILISCON_TEMPERATURE_BYTES[0], 0x00, &cval[0]);
-    readSerialRegister(CCD_SILISCON_TEMPERATURE_BYTES[1], 0x00, &cval[1]);
+    readSerialRegister(CCD_SILISCON_TEMPERATURE_BYTES[0], CCD_SILISCON_TEMPERATURE_BYTES[1], &cval[0]);
+    readSerialRegister(CCD_SILISCON_TEMPERATURE_BYTES[2], CCD_SILISCON_TEMPERATURE_BYTES[3], &cval[1]);
 
     INT16 adcCount = 0;
     adcCount += (INT16)(unsigned char)cval[1];
@@ -1684,8 +1684,8 @@ double Pixci::getTemperaturePcb()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(PCB_TEMPERATURE_BYTES[0], 0x00, &cval[1]);
-    readSerialRegister(PCB_TEMPERATURE_BYTES[1], 0x00, &cval[0]);
+    readSerialRegister(PCB_TEMPERATURE_BYTES[0], PCB_TEMPERATURE_BYTES[1], &cval[1]);
+    readSerialRegister(PCB_TEMPERATURE_BYTES[2], PCB_TEMPERATURE_BYTES[3], &cval[0]);
 
     INT16 lval = 0;
     lval += (INT16)(unsigned char)cval[0];
@@ -1717,14 +1717,14 @@ asynStatus Pixci::setTecTemperature(double temperature)
     cval[0] = (char)((dacCount & 0x0F00) >> 8);
     cval[1] = (char)((dacCount & 0x00FF));
 
-    writeSerialRegister(UNIT, 0x03, cval[0]);
-    return writeSerialRegister(UNIT, 0x04, cval[1]);
+    writeSerialRegister(UNIT, TEC_TEMPERATURE_BYTES[0], cval[0]);
+    return writeSerialRegister(UNIT, TEC_TEMPERATURE_BYTES[1], cval[1]);
 }
 
 unsigned char Pixci::getFpgaStatus()
 {
     char cval = 0;
-    readSerialRegister(0x00, &cval);
+    readSerialRegister(FPGA_STATUS_BYTE, &cval);
     // TODO: implement proper error handling
     return (unsigned char)cval;
 }
@@ -1733,9 +1733,9 @@ asynStatus Pixci::toggleTec(bool enableTec)
 {
     unsigned char fpgaStatus = getFpgaStatus();
     if (enableTec)
-        return writeSerialRegister(UNIT, 0x00, fpgaStatus | 0x01); // setting first bit = 1
+        return writeSerialRegister(UNIT, FPGA_STATUS_BYTE, fpgaStatus | 0x01); // setting first bit = 1
     else
-        return writeSerialRegister(UNIT, 0x00, fpgaStatus & ~(0x01)); // setting first bit = 0
+        return writeSerialRegister(UNIT, FPGA_STATUS_BYTE, fpgaStatus & ~(0x01)); // setting first bit = 0
 }
 
 bool Pixci::isTecEnabled()
@@ -1748,9 +1748,9 @@ asynStatus Pixci::toggleGain(bool enableGain)
 {
     unsigned char fpgaStatus = getFpgaStatus();
     if (enableGain)
-        return writeSerialRegister(UNIT, 0x00, fpgaStatus | (1 << 7)); // setting last bit = 1
+        return writeSerialRegister(UNIT, FPGA_STATUS_BYTE, fpgaStatus | (1 << 7)); // setting last bit = 1
     else
-        return writeSerialRegister(UNIT, 0x00, fpgaStatus & ~(1 << 7)); // setting last bit = 0
+        return writeSerialRegister(UNIT, FPGA_STATUS_BYTE, fpgaStatus & ~(1 << 7)); // setting last bit = 0
 }
 
 bool Pixci::isGainEnabled()
@@ -1764,7 +1764,7 @@ unsigned char Pixci::getSystemStatus()
     char cval = 0;
     char inputMsg[2];
     int inSize;
-    char first_bufout[] = {0x49, END_OF_TRANSMISSION_BYTE};
+    char first_bufout[] = {GET_SYSTEM_STATUS_BYTE, END_OF_TRANSMISSION_BYTE};
 
     /*writing to serial connection*/
     inSize = writeReadSerial(UNIT, first_bufout, sizeof(first_bufout), inputMsg, 2);
@@ -1784,8 +1784,7 @@ asynStatus Pixci::setSystemStatus(char val)
     char inputMsg[1];
 
     /* template of message to write value to registers */
-    char bufout[] = {0x4F, 0x00, END_OF_TRANSMISSION_BYTE};
-    bufout[1] = val;
+    char bufout[] = {SET_SYSTEM_STATUS_BYTE, val, END_OF_TRANSMISSION_BYTE};
 
     /*writing to serial connection*/
     inSize = writeReadSerial(UNIT, bufout, sizeof(bufout), inputMsg, 1);
@@ -1826,24 +1825,23 @@ asynStatus Pixci::setExposure(double exposureTime)
     exposureTimeCount = (unsigned long)(exposureTime * EXPOSURE_COUNT_TO_TIME / SEC_TO_mS);
     longTouchar(exposureTimeCount, exposureTimeHexVal);
 
-    writeSerialRegister(UNIT, 0xED, exposureTimeHexVal[0]);
-    writeSerialRegister(UNIT, 0xEE, exposureTimeHexVal[1]);
-    writeSerialRegister(UNIT, 0xEF, exposureTimeHexVal[2]);
-    writeSerialRegister(UNIT, 0xF0, exposureTimeHexVal[3]);
-    return writeSerialRegister(UNIT, 0xF1, exposureTimeHexVal[4]);
+    writeSerialRegister(UNIT, EXPOSURE_BYTES[0], exposureTimeHexVal[0]);
+    writeSerialRegister(UNIT, EXPOSURE_BYTES[1], exposureTimeHexVal[1]);
+    writeSerialRegister(UNIT, EXPOSURE_BYTES[2], exposureTimeHexVal[2]);
+    writeSerialRegister(UNIT, EXPOSURE_BYTES[3], exposureTimeHexVal[3]);
+    return writeSerialRegister(UNIT, EXPOSURE_BYTES[4], exposureTimeHexVal[4]);
 }
 
 double Pixci::getExposure()
 {
     char cval[5] = {0, 0, 0, 0, 0};
     double exposureTime = 0.0;
-    asynStatus status;
     unsigned long long exposureTimeCount = 0;
-    readSerialRegister(0XED, &cval[0]);
-    readSerialRegister(0xEE, &cval[1]);
-    readSerialRegister(0xEF, &cval[2]);
-    readSerialRegister(0XF0, &cval[3]);
-    readSerialRegister(0XF1, &cval[4]);
+    readSerialRegister(EXPOSURE_BYTES[0], &cval[0]);
+    readSerialRegister(EXPOSURE_BYTES[1], &cval[1]);
+    readSerialRegister(EXPOSURE_BYTES[2], &cval[2]);
+    readSerialRegister(EXPOSURE_BYTES[3], &cval[3]);
+    readSerialRegister(EXPOSURE_BYTES[4], &cval[4]);
 
     exposureTimeCount = UcharToLong(cval);
     if (exposureTimeCount > 0)
@@ -2024,9 +2022,13 @@ asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
     char inputMsg[20];
 
     /* template of message to write value to registers */
-    char bufout[] = {0x53, 0xE0, 0x02, 0x00, 0x00, END_OF_TRANSMISSION_BYTE};
-    bufout[3] = Register;
-    bufout[4] = val;
+    char bufout[] = {
+        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0], 
+        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[1], 
+        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[2], 
+        Register, val, 
+        END_OF_TRANSMISSION_BYTE
+    };
 
     /*writing to serial connection*/
     inSize = writeReadSerial(UNIT, bufout, 6, inputMsg, 20);
@@ -2047,9 +2049,19 @@ asynStatus Pixci::readSerialRegister(char Register, char *val)
 {
     char inputMsg[20];
     int inSize;
-    char first_bufout[] = {0x53, 0xE0, 0x01, 0xFF, END_OF_TRANSMISSION_BYTE};
-    char last_bufout[] = {0x53, 0xE1, 0x01, END_OF_TRANSMISSION_BYTE};
-    first_bufout[3] = Register;
+    char first_bufout[] = {
+        SINGLE_OUTPUT_BYTE_PREFIX_BYTES[0], 
+        SINGLE_OUTPUT_BYTE_PREFIX_BYTES[1], 
+        SINGLE_OUTPUT_BYTE_PREFIX_BYTES[2], 
+        Register, 
+        END_OF_TRANSMISSION_BYTE
+    };
+    char last_bufout[] = {
+        READ_SERIAL_PREFIX_BYTES[0], 
+        READ_SERIAL_PREFIX_BYTES[1], 
+        READ_SERIAL_PREFIX_BYTES[2], 
+        END_OF_TRANSMISSION_BYTE
+    };
 
     /*writing to serial connection*/
     inSize = writeReadSerial(UNIT, first_bufout, sizeof(first_bufout), inputMsg, 20);
@@ -2067,10 +2079,19 @@ asynStatus Pixci::readSerialRegister(char Register1, char Register2, char *val)
 {
     char inputMsg[20];
     int inSize;
-    char first_bufout[] = {0x53, 0xE0, 0x02, 0xFF, 0xFF, END_OF_TRANSMISSION_BYTE};
-    char last_bufout[] = {0x53, 0xE1, 0x01, END_OF_TRANSMISSION_BYTE};
-    first_bufout[3] = Register1;
-    first_bufout[4] = Register2;
+    char first_bufout[] = {
+        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0], 
+        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[1], 
+        DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[2], 
+        Register1, Register2, 
+        END_OF_TRANSMISSION_BYTE
+    };
+    char last_bufout[] = {
+        READ_SERIAL_PREFIX_BYTES[0], 
+        READ_SERIAL_PREFIX_BYTES[1], 
+        READ_SERIAL_PREFIX_BYTES[2], 
+        END_OF_TRANSMISSION_BYTE
+    };
 
     /*writing to serial connection*/
     inSize = writeReadSerial(UNIT, first_bufout, sizeof(first_bufout), inputMsg, 20);
@@ -2090,25 +2111,25 @@ asynStatus Pixci::setTriggerMode(int mode)
     switch (mode)
     {
     case PR_INTERNAL_ITR:
-        hexval = 0x04; // 00000100
+        hexval = INTERNAL_ITR_BYTE; // 00000100
         break;
     case PR_INTERNAL_FFR:
-        hexval = 0X06; // 00000110
+        hexval = INTERNAL_FFR_BYTE; // 00000110
         break;
     case PR_EXTERNAL:
         int triggerPolarity;
         getIntegerParam(PR_TriggerPolarity, &triggerPolarity);
         if (triggerPolarity == PR_EXT_FALLING_EDGE)
         {
-            hexval = 0xc0; // 11000000
+            hexval = EXTERNAL_FALLING_EDGE_BYTE; // 11000000
         }
         else
         {
-            hexval = 0x40; // 01000000
+            hexval = EXTERNAL_RISING_EDGE_BYTE; // 01000000
         }
         break;
     case PR_BUTTON_TRIGGER:
-        hexval = 0x00; // 00000000
+        hexval = CLEAR_TRIGGER_MODE_BYTE; // 00000000
         break;
     default:
         asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "invalid trigger mode value %d", mode);
@@ -2120,8 +2141,7 @@ asynStatus Pixci::setTriggerMode(int mode)
 
 asynStatus Pixci::sendSoftTrigger()
 {
-    char hexval = 0x01;
-    return Pixci::writeSerialRegister(UNIT, TRIGGER_MODE_BYTE, hexval);
+    return Pixci::writeSerialRegister(UNIT, TRIGGER_MODE_BYTE, SOFT_TRIGGER_BYTE);
 }
 
 // PV Updating Functions
@@ -2144,8 +2164,23 @@ asynStatus Pixci::updateManufacturersData(bool callBackFlag)
 
     char inputMsg[20];
     int inSize;
-    char first_bufout[] = {0x53, 0xAE, 0x05, 0x01, 0x00, 0x00, 0x02, 0x00, END_OF_TRANSMISSION_BYTE};
-    char last_bufout[] = {0x53, 0xAF, 0x12, END_OF_TRANSMISSION_BYTE};
+    char first_bufout[] = {
+        GET_MISC_DATA_BYTES[0], 
+        GET_MISC_DATA_BYTES[1], 
+        GET_MISC_DATA_BYTES[2], 
+        GET_MISC_DATA_BYTES[3], 
+        GET_MISC_DATA_BYTES[4], 
+        GET_MISC_DATA_BYTES[5], 
+        GET_MISC_DATA_BYTES[6], 
+        GET_MISC_DATA_BYTES[7], 
+        END_OF_TRANSMISSION_BYTE
+    };
+    char last_bufout[] = {
+        MANUFACTURER_DATA_BYTES[0], 
+        MANUFACTURER_DATA_BYTES[1], 
+        MANUFACTURER_DATA_BYTES[2], 
+        END_OF_TRANSMISSION_BYTE
+    };
 
     INT16 serialNumber = 0;
     string buildDate = "";
@@ -2249,8 +2284,8 @@ asynStatus Pixci::setRoiSizeX(int RoisizeX)
     cval[0] = (char)((RoisizeX & 0x0F00) >> 8);
     cval[1] = (char)((RoisizeX & 0x00FF));
 
-    writeSerialRegister(UNIT, 0xB4, cval[0]);
-    return writeSerialRegister(UNIT, 0xB5, cval[1]);
+    writeSerialRegister(UNIT, ROI_X_SIZE_BYTES[0], cval[0]);
+    return writeSerialRegister(UNIT, ROI_X_SIZE_BYTES[1], cval[1]);
 }
 
 asynStatus Pixci::setRoiSizeY(int RoisizeY)
@@ -2259,8 +2294,8 @@ asynStatus Pixci::setRoiSizeY(int RoisizeY)
     cval[0] = (char)((RoisizeY & 0x0F00) >> 8);
     cval[1] = (char)((RoisizeY & 0x00FF));
 
-    writeSerialRegister(UNIT, 0xB8, cval[0]);
-    return writeSerialRegister(UNIT, 0xB9, cval[1]);
+    writeSerialRegister(UNIT, ROI_Y_SIZE_BYTES[0], cval[0]);
+    return writeSerialRegister(UNIT, ROI_Y_SIZE_BYTES[1], cval[1]);
 }
 
 asynStatus Pixci::setRoiOffsetX(int RoiOffsetX)
@@ -2269,8 +2304,8 @@ asynStatus Pixci::setRoiOffsetX(int RoiOffsetX)
     cval[0] = (char)((RoiOffsetX & 0x0F00) >> 8);
     cval[1] = (char)((RoiOffsetX & 0x00FF));
 
-    writeSerialRegister(UNIT, 0xB6, cval[0]);
-    return writeSerialRegister(UNIT, 0xB7, cval[1]);
+    writeSerialRegister(UNIT, ROI_X_OFFSET_BYTES[0], cval[0]);
+    return writeSerialRegister(UNIT, ROI_X_OFFSET_BYTES[1], cval[1]);
 }
 
 asynStatus Pixci::setRoiOffsetY(int RoiOffsetY)
@@ -2279,16 +2314,16 @@ asynStatus Pixci::setRoiOffsetY(int RoiOffsetY)
     cval[0] = (char)((RoiOffsetY & 0x0F00) >> 8);
     cval[1] = (char)((RoiOffsetY & 0x00FF));
 
-    writeSerialRegister(UNIT, 0xBA, cval[0]);
-    return writeSerialRegister(UNIT, 0xBB, cval[1]);
+    writeSerialRegister(UNIT, ROI_Y_OFFSET_BYTES[0], cval[0]);
+    return writeSerialRegister(UNIT, ROI_Y_OFFSET_BYTES[1], cval[1]);
 }
 
 int Pixci::getRoiSizeX()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(0XB4, &cval[1]);
-    readSerialRegister(0XB5, &cval[0]);
+    readSerialRegister(ROI_X_SIZE_BYTES[0], &cval[1]);
+    readSerialRegister(ROI_X_SIZE_BYTES[1], &cval[0]);
 
     INT16 ival = 0;
     ival += (INT16)(unsigned char)cval[0];
@@ -2301,8 +2336,8 @@ int Pixci::getRoiSizeY()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(0XB8, &cval[1]);
-    readSerialRegister(0XB9, &cval[0]);
+    readSerialRegister(ROI_Y_SIZE_BYTES[0], &cval[1]);
+    readSerialRegister(ROI_Y_SIZE_BYTES[1], &cval[0]);
 
     INT16 ival = 0;
     ival += (INT16)(unsigned char)cval[0];
@@ -2315,8 +2350,8 @@ int Pixci::getRoiOffsetX()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(0XB6, &cval[1]);
-    readSerialRegister(0XB7, &cval[0]);
+    readSerialRegister(ROI_X_OFFSET_BYTES[0], &cval[1]);
+    readSerialRegister(ROI_X_OFFSET_BYTES[1], &cval[0]);
 
     INT16 ival = 0;
     ival += (INT16)(unsigned char)cval[0];
@@ -2329,8 +2364,8 @@ int Pixci::getRoiOffsetY()
 {
     char cval[2] = {0, 0};
 
-    readSerialRegister(0XBA, &cval[1]);
-    readSerialRegister(0XBB, &cval[0]);
+    readSerialRegister(ROI_Y_OFFSET_BYTES[0], &cval[1]);
+    readSerialRegister(ROI_Y_OFFSET_BYTES[1], &cval[0]);
 
     INT16 ival = 0;
     ival += (INT16)(unsigned char)cval[0];

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -33,20 +33,6 @@ extern "C"
 
 using namespace std;
 
-#define FORMAT ""      // Video format configuration name.
-#define DRIVERPARMS "" // Default , user '-QU 0' for not using interrupts.
-#define UNIT 1         // Unit to be selected for streaming, eb1 model only have 1 unit.
-#define NOERROR 0      // Errors are defined as integers below zero.
-#define RESERVED 0
-#define BAUDRATE 115200
-
-#define BINNING1 1
-#define BINNING2 2
-#define BINNING4 4
-#define BINNING8 8
-#define BINNING16 16
-#define BINNING32 32
-
 #define BINNINGSETTINGS_1X1 "videoSettings\Raptor_Photonics_EagleXV_47-10.fmt"
 #define BINNINGSETTINGS_1X2 "videoSettings\Raptor_Photonics_EagleXV_47-10_binning1x2.fmt"
 #define BINNINGSETTINGS_1X4 "videoSettings\Raptor_Photonics_EagleXV_47-10_binning1x4.fmt"
@@ -120,16 +106,6 @@ using namespace std;
 #define BINNINGSETTINGS_4240_32X8 "videoSettings\Raptor_Photonics_EagleXV_42-40_binning32x8.fmt"
 #define BINNINGSETTINGS_4240_32X16 "videoSettings\Raptor_Photonics_EagleXV_42-40_binning32x16.fmt"
 #define BINNINGSETTINGS_4240_32X32 "videoSettings\Raptor_Photonics_EagleXV_42-40_binning32x32.fmt"
-
-#define PARAM_MESSAGE_QUE_SIZE 20
-#define PARAM_MESSAGE_SIZE 16
-#define COUNT_PER_FRAME 40e6
-
-#define DETECTOR_1024 4710
-#define DETECTOR_2048 4240
-
-#define EXPOSURE_COUNT_TO_TIME 40e6
-#define SEC_TO_mS 10e2
 
 // Set video resolution and video offset.
 // Set capture resolution to same.
@@ -1690,9 +1666,7 @@ double Pixci::getTemperaturePcb()
     INT16 lval = 0;
     lval += (INT16)(unsigned char)cval[0];
     lval += (INT16)(unsigned char)(cval[1] & 0x0F) << 8;
-    double temperature = lval / 16.0f;
-
-    return temperature;
+    return lval / 16.0;
 }
 
 double Pixci::getTecTemperature()

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -659,7 +659,7 @@ void Pixci::paramTask()
             getIntegerParam(ADTriggerMode, &triggerMode);
             if (triggerMode == PR_BUTTON_TRIGGER)
             {
-                status = Pixci::sendSoftTrigger();
+                status = Pixci::writeSerialRegister(UNIT, TRIGGER_MODE_BYTE, SOFT_TRIGGER_BYTE);
             }
             else
             {
@@ -2108,11 +2108,6 @@ asynStatus Pixci::setTriggerMode(int mode)
         break;
     }
     return Pixci::writeSerialRegister(UNIT, TRIGGER_MODE_BYTE, hexval);
-}
-
-asynStatus Pixci::sendSoftTrigger()
-{
-    return Pixci::writeSerialRegister(UNIT, TRIGGER_MODE_BYTE, SOFT_TRIGGER_BYTE);
 }
 
 // PV Updating Functions

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -263,7 +263,6 @@ static void paramTaskC(void *drvPvt);
 
 /* Event handler for acquire task */
 HANDLE g_hEvent;
-unsigned char g_ucSerialBuf[256];
 /*
  * @brief Configuration command for pixci driver; creates a new pixci object.
  * @param See the pixci.h
@@ -490,7 +489,7 @@ void Pixci::acquireTask()
     NDDataType_t dataType;
     epicsInt32 sizeX, sizeY;
     epicsInt32 binX, binY;
-    size_t dims[2];
+    size_t dims[2] = {};
     epicsTimeStamp currentTime;
     epicsInt32 numImagesCounter;
     epicsInt32 imageCounter;
@@ -560,7 +559,7 @@ static void paramTaskC(void *drvPvt)
 
 void Pixci::paramTask()
 {
-    epicsFloat64 functionAndVal[2];
+    epicsFloat64 functionAndVal[2] = {};
     epicsInt32 function;
     epicsFloat64 d_val;
     epicsInt32 i_val;
@@ -1497,7 +1496,7 @@ void Pixci::epicsUInt64ToUChar(epicsUInt64 lval, char *cval)
 int Pixci::writeReadSerial(int unit, char *serialOut, int msgOutSize, char *serialIn, int serialInBufferSize)
 {
     int count, i;
-    char bufOut[50];
+    char bufOut[50] = {};
     char chkSum = 0;
     int outMsgwait = 0;
     int inMsgwait = 0;
@@ -1732,7 +1731,7 @@ bool Pixci::isGainEnabled()
 unsigned char Pixci::getSystemStatus()
 {
     char cval = 0;
-    char inputMsg[2];
+    char inputMsg[2] = {};
     char first_bufout[] = {GET_SYSTEM_STATUS_BYTE, END_OF_TRANSMISSION_BYTE};
 
     /*writing to serial connection*/
@@ -1749,7 +1748,7 @@ unsigned char Pixci::getSystemStatus()
 
 asynStatus Pixci::setSystemStatus(char val)
 {
-    char inputMsg[1];
+    char inputMsg[1] = {};
 
     /* template of message to write value to registers */
     char bufout[] = {SET_SYSTEM_STATUS_BYTE, val, END_OF_TRANSMISSION_BYTE};
@@ -1964,25 +1963,21 @@ asynStatus Pixci::writeFloat64(asynUser *pasynUser, epicsFloat64 value)
 
 void Pixci::addToParamQue(epicsInt32 function, epicsInt32 value)
 {
-    epicsFloat64 functionAndVal[2];
-    functionAndVal[0] = function;
-    functionAndVal[1] = value;
+    epicsFloat64 functionAndVal[2] = {static_cast<epicsFloat64>(function), static_cast<epicsFloat64>(value)};
     /*sending buffer data to the queue */
     paramMsgQue->send(functionAndVal, PARAM_MESSAGE_SIZE);
 }
 
 void Pixci::addToParamQue(epicsInt32 function, epicsFloat64 value)
 {
-    epicsFloat64 functionAndVal[2];
-    functionAndVal[0] = function;
-    functionAndVal[1] = value;
+    epicsFloat64 functionAndVal[2] = {static_cast<epicsFloat64>(function), value};
     /*sending buffer data to the queue */
     paramMsgQue->send(functionAndVal, PARAM_MESSAGE_SIZE);
 }
 
 asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
 {
-    char inputMsg[20];
+    char inputMsg[20] = {};
 
     /* template of message to write value to registers */
     char bufout[] = {
@@ -2010,7 +2005,7 @@ asynStatus Pixci::writeSerialRegister(int unit, char Register, char val)
 
 asynStatus Pixci::readSerialRegister(char Register, char *val)
 {
-    char inputMsg[20];
+    char inputMsg[20] = {};
     int inSize;
     char first_bufout[] = {
          static_cast<char>(SINGLE_OUTPUT_BYTE_PREFIX_BYTES[0]), 
@@ -2040,7 +2035,7 @@ asynStatus Pixci::readSerialRegister(char Register, char *val)
 
 asynStatus Pixci::readSerialRegister(char Register1, char Register2, char *val)
 {
-    char inputMsg[20];
+    char inputMsg[20] = {};
     int inSize;
     char first_bufout[] = {
          static_cast<char>(DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[0]), 
@@ -2119,7 +2114,7 @@ void Pixci::updateTemperaturePcb(bool callBackFlag)
 
 asynStatus Pixci::updateManufacturersData(bool callBackFlag)
 {
-    char inputMsg[20];
+    char inputMsg[20] = {};
     int inSize;
     char first_bufout[] = {
          static_cast<char>(GET_MISC_DATA_BYTES[0]), 
@@ -2141,7 +2136,6 @@ asynStatus Pixci::updateManufacturersData(bool callBackFlag)
 
     INT16 serialNumber = 0;
     string buildDate = "";
-    char buildCode[5];
     INT16 adcCountZeroDegree = 0;
     INT16 adcCountFortyDegree = 0;
     INT16 dacCountZeroDegree = 0;
@@ -2164,12 +2158,6 @@ asynStatus Pixci::updateManufacturersData(bool callBackFlag)
 
         buildDate = to_string((INT16)(unsigned char)inputMsg[2]) + "/" + to_string((INT16)(unsigned char)inputMsg[3]) + "/" + to_string((INT16)(unsigned char)inputMsg[4]);
         setStringParam(PR_BuildDate, buildDate);
-
-        buildCode[0] = inputMsg[5];
-        buildCode[1] = inputMsg[6];
-        buildCode[2] = inputMsg[7];
-        buildCode[3] = inputMsg[8];
-        buildCode[4] = inputMsg[9];
 
         adcCountZeroDegree += (INT16)(unsigned char)inputMsg[10];
         adcCountZeroDegree += (INT16)(unsigned char)(inputMsg[11]) << 8;

--- a/pixciApp/src/pixci.h
+++ b/pixciApp/src/pixci.h
@@ -23,8 +23,32 @@ static const char *driverName = "Pixci";
 #define DACCalibrationZeroDegreeString "PR_DAC_CALIBRATION_ZERO_DEGREE"
 #define DACCalibrationFortyDegreeString "PR_DAC_CALIBRATION_FORTY_DEGREE"
 
+#define BINNING1 1
+#define BINNING2 2
+#define BINNING4 4
+#define BINNING8 8
+#define BINNING16 16
+#define BINNING32 32
+
+#define DETECTOR_1024 4710
+#define DETECTOR_2048 4240
+
+#define NOERROR 0      // Errors are defined as integers below zero.
+
+constexpr const char* FORMAT = "";      // Video format configuration name.
+constexpr const char* DRIVERPARMS = ""; // Default , user '-QU 0' for not using interrupts.
+constexpr epicsInt32 UNIT = 1;        // Unit to be selected for streaming, eb1 model only have 1 unit.
+constexpr epicsInt32 RESERVED  = 0;
+constexpr epicsFloat64 BAUDRATE = 115200;
+
 constexpr epicsBoolean BIN_AXIS_X = epicsFalse;
 constexpr epicsBoolean BIN_AXIS_Y = epicsTrue;
+
+constexpr epicsUInt32 PARAM_MESSAGE_QUE_SIZE = 20;
+constexpr epicsUInt32 PARAM_MESSAGE_SIZE = 16;
+constexpr epicsFloat64 COUNT_PER_FRAME = 40e6;
+constexpr epicsFloat64 EXPOSURE_COUNT_TO_TIME = 40e6;
+constexpr epicsFloat64 SEC_TO_mS = 10e2;
 
 constexpr epicsUInt8 SUCCESS_MESSAGE = 0x50;
 constexpr epicsUInt8 END_OF_TRANSMISSION_BYTE = 0x50;
@@ -51,11 +75,11 @@ constexpr epicsUInt8 READ_SERIAL_PREFIX_BYTES[3] = {0x53, 0xE1, 0x01};
 constexpr epicsUInt8 GET_MISC_DATA_BYTES[8] = {0x53, 0xAE, 0x05, 0x01, 0x00, 0x00, 0x02, 0x00};
 constexpr epicsUInt8 MANUFACTURER_DATA_BYTES[3] = {0x53, 0xAF, 0x12};
 
+constexpr epicsUInt8 EXPOSURE_BYTES[5] = {0xED, 0xEE, 0xEF, 0xF0, 0xF1};
 constexpr epicsUInt8 FRAME_RATE_BYTES[5] = {0xDC, 0xDD, 0xDE, 0xDF, 0xE0};
 constexpr epicsUInt8 PCB_TEMPERATURE_BYTES[4] = {0X70, 0x00, 0X71, 0x00};
 constexpr epicsUInt8 CCD_SILISCON_TEMPERATURE_BYTES[4] = {0X6E, 0x00, 0X6F, 0x00};
 constexpr epicsUInt8 TEC_TEMPERATURE_BYTES[2] = {0X03, 0X04};
-constexpr epicsUInt8 EXPOSURE_BYTES[5] = {0xED, 0xEE, 0xEF, 0xF0, 0xF1};
 constexpr epicsUInt8 ROI_X_SIZE_BYTES[2] = {0xB4, 0xB5};
 constexpr epicsUInt8 ROI_Y_SIZE_BYTES[2] = {0xB8, 0xB9};
 constexpr epicsUInt8 ROI_X_OFFSET_BYTES[2] = {0xB6, 0xB7};

--- a/pixciApp/src/pixci.h
+++ b/pixciApp/src/pixci.h
@@ -23,8 +23,19 @@ static const char *driverName = "Pixci";
 #define DACCalibrationZeroDegreeString "PR_DAC_CALIBRATION_ZERO_DEGREE"
 #define DACCalibrationFortyDegreeString "PR_DAC_CALIBRATION_FORTY_DEGREE"
 
-#define BinAxisX 0
-#define BinAxisY 1
+constexpr epicsBoolean BIN_AXIS_X = epicsFalse;
+constexpr epicsBoolean BIN_AXIS_Y = epicsTrue;
+constexpr epicsUInt8 SUCCESS_MESSAGE = 0x50;
+constexpr epicsUInt8 END_OF_TRANSMISSION_BYTE = 0x50;
+constexpr epicsUInt8 TRIGGER_MODE_BYTE = 0xD4;
+constexpr epicsUInt8 X_BIN_BYTE = 0xA1;
+constexpr epicsUInt8 Y_BIN_BYTE = 0xA2;
+
+constexpr epicsUInt8 FRAME_RATE_BYTES[5] = {0xDC, 0xDD, 0xDE, 0xDF, 0xE0};
+constexpr epicsUInt8 PCB_TEMPERATURE_BYTES[2] = {0X70, 0X71};
+constexpr epicsUInt8 CCD_SILISCON_TEMPERATURE_BYTES[2] = {0X6E, 0X6F};
+constexpr epicsUInt8 TEC_TEMPERATURE_BYTES[2] = {0X03, 0X04};
+
 
 /* Trigger modes of Raptor Eagle-XV" */
 /*ITR mode will be used to capture a continuous sequence of images.
@@ -202,7 +213,7 @@ private:
      * @param coordinate 0 for x axis and 1 for y axis.
      * @return asynStatus
      */
-    asynStatus setBin(int val, bool coordinate);
+    asynStatus setBin(epicsInt32 val, epicsBoolean coordinate);
 
     /**
      * @brief queue for changing parameters that use serial communication.

--- a/pixciApp/src/pixci.h
+++ b/pixciApp/src/pixci.h
@@ -37,53 +37,53 @@ static const char *driverName = "Pixci";
 
 constexpr const char* FORMAT = "";      // Video format configuration name.
 constexpr const char* DRIVERPARMS = ""; // Default , user '-QU 0' for not using interrupts.
-constexpr epicsInt32 UNIT = 1;        // Unit to be selected for streaming, eb1 model only have 1 unit.
-constexpr epicsInt32 RESERVED  = 0;
-constexpr epicsFloat64 BAUDRATE = 115200;
+constexpr const epicsInt32 UNIT = 1;        // Unit to be selected for streaming, eb1 model only have 1 unit.
+constexpr const epicsInt32 RESERVED  = 0;
+constexpr const epicsFloat64 BAUDRATE = 115200;
 
-constexpr epicsBoolean BIN_AXIS_X = epicsFalse;
-constexpr epicsBoolean BIN_AXIS_Y = epicsTrue;
+constexpr const epicsBoolean BIN_AXIS_X = epicsFalse;
+constexpr const epicsBoolean BIN_AXIS_Y = epicsTrue;
 
-constexpr epicsUInt32 PARAM_MESSAGE_QUE_SIZE = 20;
-constexpr epicsUInt32 PARAM_MESSAGE_SIZE = 16;
-constexpr epicsFloat64 COUNT_PER_FRAME = 40e6;
-constexpr epicsFloat64 EXPOSURE_COUNT_TO_TIME = 40e6;
-constexpr epicsFloat64 SEC_TO_mS = 10e2;
+constexpr const epicsUInt32 PARAM_MESSAGE_QUE_SIZE = 20;
+constexpr const epicsUInt32 PARAM_MESSAGE_SIZE = 16;
+constexpr const epicsFloat64 COUNT_PER_FRAME = 40e6;
+constexpr const epicsFloat64 EXPOSURE_COUNT_TO_TIME = 40e6;
+constexpr const epicsFloat64 SEC_TO_mS = 10e2;
 
-constexpr epicsUInt8 SUCCESS_MESSAGE = 0x50;
-constexpr epicsUInt8 END_OF_TRANSMISSION_BYTE = 0x50;
+constexpr const epicsInt8 SUCCESS_MESSAGE = 0x50;
+constexpr const epicsInt8 END_OF_TRANSMISSION_BYTE = 0x50;
 
-constexpr epicsUInt8 X_BIN_BYTE = 0xA1;
-constexpr epicsUInt8 Y_BIN_BYTE = 0xA2;
+constexpr const epicsUInt8 X_BIN_BYTE = 0xA1;
+constexpr const epicsUInt8 Y_BIN_BYTE = 0xA2;
 
-constexpr epicsUInt8 FPGA_STATUS_BYTE = 0x00;
-constexpr epicsUInt8 GET_SYSTEM_STATUS_BYTE = 0x49;
-constexpr epicsUInt8 SET_SYSTEM_STATUS_BYTE = 0x4F;
+constexpr const epicsUInt8 FPGA_STATUS_BYTE = 0x00;
+constexpr const epicsUInt8 GET_SYSTEM_STATUS_BYTE = 0x49;
+constexpr const epicsUInt8 SET_SYSTEM_STATUS_BYTE = 0x4F;
 
-constexpr epicsUInt8 TRIGGER_MODE_BYTE = 0xD4;
-constexpr epicsUInt8 CLEAR_TRIGGER_MODE_BYTE = 0x00;
-constexpr epicsUInt8 SOFT_TRIGGER_BYTE = 0x01;
-constexpr epicsUInt8 INTERNAL_ITR_BYTE = 0x04;
-constexpr epicsUInt8 INTERNAL_FFR_BYTE = 0x06;
-constexpr epicsUInt8 EXTERNAL_FALLING_EDGE_BYTE = 0xC0;
-constexpr epicsUInt8 EXTERNAL_RISING_EDGE_BYTE = 0x40;
+constexpr const epicsUInt8 TRIGGER_MODE_BYTE = 0xD4;
+constexpr const epicsUInt8 CLEAR_TRIGGER_MODE_BYTE = 0x00;
+constexpr const epicsUInt8 SOFT_TRIGGER_BYTE = 0x01;
+constexpr const epicsUInt8 INTERNAL_ITR_BYTE = 0x04;
+constexpr const epicsUInt8 INTERNAL_FFR_BYTE = 0x06;
+constexpr const epicsUInt8 EXTERNAL_FALLING_EDGE_BYTE = 0xC0;
+constexpr const epicsUInt8 EXTERNAL_RISING_EDGE_BYTE = 0x40;
 
-constexpr epicsUInt8 SINGLE_OUTPUT_BYTE_PREFIX_BYTES[3] = {0x53, 0xE0, 0x01};
-constexpr epicsUInt8 DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[3] = {0x53, 0xE0, 0x02};
-constexpr epicsUInt8 READ_SERIAL_PREFIX_BYTES[3] = {0x53, 0xE1, 0x01};
+constexpr const epicsUInt8 SINGLE_OUTPUT_BYTE_PREFIX_BYTES[3] = {0x53, 0xE0, 0x01};
+constexpr const epicsUInt8 DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[3] = {0x53, 0xE0, 0x02};
+constexpr const epicsUInt8 READ_SERIAL_PREFIX_BYTES[3] = {0x53, 0xE1, 0x01};
 
-constexpr epicsUInt8 GET_MISC_DATA_BYTES[8] = {0x53, 0xAE, 0x05, 0x01, 0x00, 0x00, 0x02, 0x00};
-constexpr epicsUInt8 MANUFACTURER_DATA_BYTES[3] = {0x53, 0xAF, 0x12};
+constexpr const epicsUInt8 GET_MISC_DATA_BYTES[8] = {0x53, 0xAE, 0x05, 0x01, 0x00, 0x00, 0x02, 0x00};
+constexpr const epicsUInt8 MANUFACTURER_DATA_BYTES[3] = {0x53, 0xAF, 0x12};
 
-constexpr epicsUInt8 EXPOSURE_BYTES[5] = {0xED, 0xEE, 0xEF, 0xF0, 0xF1};
-constexpr epicsUInt8 FRAME_RATE_BYTES[5] = {0xDC, 0xDD, 0xDE, 0xDF, 0xE0};
-constexpr epicsUInt8 PCB_TEMPERATURE_BYTES[4] = {0X70, 0x00, 0X71, 0x00};
-constexpr epicsUInt8 CCD_SILISCON_TEMPERATURE_BYTES[4] = {0X6E, 0x00, 0X6F, 0x00};
-constexpr epicsUInt8 TEC_TEMPERATURE_BYTES[2] = {0X03, 0X04};
-constexpr epicsUInt8 ROI_X_SIZE_BYTES[2] = {0xB4, 0xB5};
-constexpr epicsUInt8 ROI_Y_SIZE_BYTES[2] = {0xB8, 0xB9};
-constexpr epicsUInt8 ROI_X_OFFSET_BYTES[2] = {0xB6, 0xB7};
-constexpr epicsUInt8 ROI_Y_OFFSET_BYTES[2] = {0xBA, 0xBB};
+constexpr const epicsUInt8 EXPOSURE_BYTES[5] = {0xED, 0xEE, 0xEF, 0xF0, 0xF1};
+constexpr const epicsUInt8 FRAME_RATE_BYTES[5] = {0xDC, 0xDD, 0xDE, 0xDF, 0xE0};
+constexpr const epicsUInt8 PCB_TEMPERATURE_BYTES[4] = {0X70, 0x00, 0X71, 0x00};
+constexpr const epicsUInt8 CCD_SILISCON_TEMPERATURE_BYTES[4] = {0X6E, 0x00, 0X6F, 0x00};
+constexpr const epicsUInt8 TEC_TEMPERATURE_BYTES[2] = {0X03, 0X04};
+constexpr const epicsUInt8 ROI_X_SIZE_BYTES[2] = {0xB4, 0xB5};
+constexpr const epicsUInt8 ROI_Y_SIZE_BYTES[2] = {0xB8, 0xB9};
+constexpr const epicsUInt8 ROI_X_OFFSET_BYTES[2] = {0xB6, 0xB7};
+constexpr const epicsUInt8 ROI_Y_OFFSET_BYTES[2] = {0xBA, 0xBB};
 
 
 /* Trigger modes of Raptor Eagle-XV" */
@@ -507,7 +507,7 @@ private:
      * @param cval char array of size 5
      * @return unsigned long long
      */
-    unsigned long long UcharToLong(char *cval);
+    epicsInt64 uCharToEpicsUInt64(char *cval);
 
     /**
      * @brief convert unsigned char value to unsigned long long
@@ -515,7 +515,7 @@ private:
      * @param lval unsigned long long value
      * @param cval address of unsigned char array of size 5
      */
-    void longTouchar(long lval, char *cval);
+    void epicsUInt64ToUChar(epicsUInt64 lval, char *cval);
 
     /**
      * @brief Set the Acquire Time (exposure)

--- a/pixciApp/src/pixci.h
+++ b/pixciApp/src/pixci.h
@@ -23,6 +23,9 @@ static const char *driverName = "Pixci";
 #define DACCalibrationZeroDegreeString "PR_DAC_CALIBRATION_ZERO_DEGREE"
 #define DACCalibrationFortyDegreeString "PR_DAC_CALIBRATION_FORTY_DEGREE"
 
+#define BinAxisX 0
+#define BinAxisY 1
+
 /* Trigger modes of Raptor Eagle-XV" */
 /*ITR mode will be used to capture a continuous sequence of images.
  The camera will immediately trigger the start of a new integration period
@@ -215,8 +218,8 @@ private:
      * @param function
      * @param value
      */
-    void addToParamQue(int function, int value);
-    void addToParamQue(int function, epicsFloat64 value);
+    void addToParamQue(epicsInt32 function, epicsInt32 value);
+    void addToParamQue(epicsInt32 function, epicsFloat64 value);
 
     /**
      * @brief write value to the registers of the camera using serial command, might take longer
@@ -240,6 +243,13 @@ private:
      * @return asynStatus
      */
     asynStatus setTriggerMode(int mode);
+
+    /**
+     * @brief Send a soft trigger to the camera to capture one image.
+     *
+     * @return asynStatus
+     */
+    asynStatus Pixci::sendSoftTrigger();
 
     /**
      * @brief Set the Frame Rate for Internal FFR mode

--- a/pixciApp/src/pixci.h
+++ b/pixciApp/src/pixci.h
@@ -185,6 +185,9 @@ private:
     float DAC_M; // DAC Slope
     float DAC_C; // DAC Offset
     int cameraModel;
+    
+    /* Event handler for acquire task */
+    HANDLE g_hEvent;
 
     /**
      * @brief starts live capture image to frame buffer.

--- a/pixciApp/src/pixci.h
+++ b/pixciApp/src/pixci.h
@@ -507,7 +507,7 @@ private:
      * @param cval char array of size 5
      * @return unsigned long long
      */
-    epicsInt64 uCharToEpicsUInt64(char *cval);
+    epicsUInt64 uCharToEpicsUInt64(char *cval);
 
     /**
      * @brief convert unsigned char value to unsigned long long

--- a/pixciApp/src/pixci.h
+++ b/pixciApp/src/pixci.h
@@ -25,16 +25,41 @@ static const char *driverName = "Pixci";
 
 constexpr epicsBoolean BIN_AXIS_X = epicsFalse;
 constexpr epicsBoolean BIN_AXIS_Y = epicsTrue;
+
 constexpr epicsUInt8 SUCCESS_MESSAGE = 0x50;
 constexpr epicsUInt8 END_OF_TRANSMISSION_BYTE = 0x50;
-constexpr epicsUInt8 TRIGGER_MODE_BYTE = 0xD4;
+
 constexpr epicsUInt8 X_BIN_BYTE = 0xA1;
 constexpr epicsUInt8 Y_BIN_BYTE = 0xA2;
 
+constexpr epicsUInt8 FPGA_STATUS_BYTE = 0x00;
+constexpr epicsUInt8 GET_SYSTEM_STATUS_BYTE = 0x49;
+constexpr epicsUInt8 SET_SYSTEM_STATUS_BYTE = 0x4F;
+
+constexpr epicsUInt8 TRIGGER_MODE_BYTE = 0xD4;
+constexpr epicsUInt8 CLEAR_TRIGGER_MODE_BYTE = 0x00;
+constexpr epicsUInt8 SOFT_TRIGGER_BYTE = 0x01;
+constexpr epicsUInt8 INTERNAL_ITR_BYTE = 0x04;
+constexpr epicsUInt8 INTERNAL_FFR_BYTE = 0x06;
+constexpr epicsUInt8 EXTERNAL_FALLING_EDGE_BYTE = 0xC0;
+constexpr epicsUInt8 EXTERNAL_RISING_EDGE_BYTE = 0x40;
+
+constexpr epicsUInt8 SINGLE_OUTPUT_BYTE_PREFIX_BYTES[3] = {0x53, 0xE0, 0x01};
+constexpr epicsUInt8 DOUBLE_OUTPUT_BYTE_PREFIX_BYTES[3] = {0x53, 0xE0, 0x02};
+constexpr epicsUInt8 READ_SERIAL_PREFIX_BYTES[3] = {0x53, 0xE1, 0x01};
+
+constexpr epicsUInt8 GET_MISC_DATA_BYTES[8] = {0x53, 0xAE, 0x05, 0x01, 0x00, 0x00, 0x02, 0x00};
+constexpr epicsUInt8 MANUFACTURER_DATA_BYTES[3] = {0x53, 0xAF, 0x12};
+
 constexpr epicsUInt8 FRAME_RATE_BYTES[5] = {0xDC, 0xDD, 0xDE, 0xDF, 0xE0};
-constexpr epicsUInt8 PCB_TEMPERATURE_BYTES[2] = {0X70, 0X71};
-constexpr epicsUInt8 CCD_SILISCON_TEMPERATURE_BYTES[2] = {0X6E, 0X6F};
+constexpr epicsUInt8 PCB_TEMPERATURE_BYTES[4] = {0X70, 0x00, 0X71, 0x00};
+constexpr epicsUInt8 CCD_SILISCON_TEMPERATURE_BYTES[4] = {0X6E, 0x00, 0X6F, 0x00};
 constexpr epicsUInt8 TEC_TEMPERATURE_BYTES[2] = {0X03, 0X04};
+constexpr epicsUInt8 EXPOSURE_BYTES[5] = {0xED, 0xEE, 0xEF, 0xF0, 0xF1};
+constexpr epicsUInt8 ROI_X_SIZE_BYTES[2] = {0xB4, 0xB5};
+constexpr epicsUInt8 ROI_Y_SIZE_BYTES[2] = {0xB8, 0xB9};
+constexpr epicsUInt8 ROI_X_OFFSET_BYTES[2] = {0xB6, 0xB7};
+constexpr epicsUInt8 ROI_Y_OFFSET_BYTES[2] = {0xBA, 0xBB};
 
 
 /* Trigger modes of Raptor Eagle-XV" */


### PR DESCRIPTION
Defined several constants in `Pixci.h` and moved existing ones there - used the `constexpr const` format for this.
Changed some types to epics types, added some explicit type conversions to stop compiler warnings.