### PR TITLE
102 temperature autosaving should be off

### DIFF
--- a/pixciApp/Db/Pixci.template
+++ b/pixciApp/Db/Pixci.template
@@ -159,6 +159,14 @@ record(ai, "$(P)$(R)DACCalibrationFortyDegree_RBV")
    field(SCAN, "I/O Intr")
 }
 
+# Override Temperature from ADCore 
+# to initialize the temperature to 20C (not 25C) and stop autosave
+record(ao, "$(P)$(R)Temperature")
+{
+   field(VAL, "20.0")
+   info(autosaveFields, "")
+}
+
 ################################################################################
 # Records related to pre amp gain
 #

--- a/pixciApp/Db/Pixci_settings.req
+++ b/pixciApp/Db/Pixci_settings.req
@@ -1,7 +1,4 @@
-$(P)$(R)SoftTrigger
 $(P)$(R)TriggerPolarity
-$(P)$(R)UpdateTemperature
-$(P)$(R)ToggleTEC
 $(P)$(R)ToggleGain
 $(P)$(R)BinX
 $(P)$(R)BinY

--- a/pixciApp/Db/Pixci_settings.req
+++ b/pixciApp/Db/Pixci_settings.req
@@ -1,6 +1,7 @@
 $(P)$(R)TriggerPolarity
 $(P)$(R)ToggleGain
 # the following is taken from ADBase_settings and modified to exclude some records
+# temperature must not be an autosave value as it can damage the detector
 $(P)$(R)BinX
 $(P)$(R)BinY
 $(P)$(R)MinX

--- a/pixciApp/Db/Pixci_settings.req
+++ b/pixciApp/Db/Pixci_settings.req
@@ -1,5 +1,6 @@
 $(P)$(R)TriggerPolarity
 $(P)$(R)ToggleGain
+# the following is taken from ADBase_settings and modified to exclude some records
 $(P)$(R)BinX
 $(P)$(R)BinY
 $(P)$(R)MinX

--- a/pixciApp/Db/Pixci_settings.req
+++ b/pixciApp/Db/Pixci_settings.req
@@ -3,4 +3,31 @@ $(P)$(R)TriggerPolarity
 $(P)$(R)UpdateTemperature
 $(P)$(R)ToggleTEC
 $(P)$(R)ToggleGain
-file "ADBase_settings.req", P=$(P), R=$(R)
+$(P)$(R)BinX
+$(P)$(R)BinY
+$(P)$(R)MinX
+$(P)$(R)MinY
+$(P)$(R)SizeX
+$(P)$(R)SizeY
+$(P)$(R)ReverseX
+$(P)$(R)ReverseY
+$(P)$(R)AcquireTime
+$(P)$(R)AcquirePeriod
+$(P)$(R)Gain
+$(P)$(R)FrameType
+$(P)$(R)ImageMode
+$(P)$(R)TriggerMode
+$(P)$(R)NumExposures
+$(P)$(R)NumImages
+$(P)$(R)ShutterMode
+$(P)$(R)ShutterOpenDelay
+$(P)$(R)ShutterCloseDelay
+$(P)$(R)ShutterOpenEPICS.OUT
+$(P)$(R)ShutterCloseEPICS.OUT
+$(P)$(R)ShutterOpenEPICS.OCAL
+$(P)$(R)ShutterCloseEPICS.OCAL
+$(P)$(R)ShutterStatusEPICS_RBV.INP
+$(P)$(R)ShutterStatusEPICS_RBV.ZRVL
+$(P)$(R)ShutterStatusEPICS_RBV.ONVL
+$(P)$(R)ReadStatus.SCAN
+file "NDArrayBase_settings.req", P=$(P), R=$(R)

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -590,8 +590,6 @@ void Pixci::paramTask()
         {
             updateADTemperatureActual();
             updateTemperaturePcb(epicsTrue);
-            epicsFloat64 tecTemperature = getTecTemperature();
-            setStatIfHigher(status, setDoubleParam(ADTemperature, tecTemperature));
         }
         else if (function == ADAcquirePeriod)
         {

--- a/pixciApp/src/pixci.cpp
+++ b/pixciApp/src/pixci.cpp
@@ -590,6 +590,8 @@ void Pixci::paramTask()
         {
             updateADTemperatureActual();
             updateTemperaturePcb(epicsTrue);
+            epicsFloat64 tecTemperature = getTecTemperature();
+            setStatIfHigher(status, setDoubleParam(ADTemperature, tecTemperature));
         }
         else if (function == ADAcquirePeriod)
         {


### PR DESCRIPTION
Turned off autosave for ADPixci's temperature record and set it to initialize to 20C.
Removed some unnecessary records from autosave.